### PR TITLE
feat: replace interprocess with Tokio native IPC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,10 +78,14 @@ jobs:
           target
         key: ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.lock') }}
     
-    - name: Run cross-platform tests
+    - name: Check cross-platform build
+      run: cargo check --all-features
+
+    - name: Run IPC transport integration tests
+      run: cargo test --all-features --test ipc_transport
+
+    - name: Run complete cross-platform test suite
       run: |
-        # Ensure we can build and test on this platform
-        cargo check --all-features
         make test
 
   docs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-08-15
+
+### Changed
+
+- Replace the `interprocess` transport with a thin kode-bridge transport layer backed directly by Tokio Unix domain sockets and Windows named pipes.
+- Replace public `interprocess` types with kode-bridge's `Endpoint`, `ListenerOptions`, and `IpcStream` types. Client and server constructors, server permission builders, and pooled stream accessors keep their existing method names.
+- Change `ConnectionPool::new` and `ConnectionPool::with_default_config` to accept a validated `Endpoint`.
+- Preserve the existing HTTP-over-IPC wire format, request behavior, connection pooling, streaming, timeouts, and retry configuration.
+- Preserve the 0.4 Windows named-pipe buffer and flush/linger behavior using 512-byte pipe buffers and a cancellation-independent background flush queue.
+- Raise the minimum supported Rust version from 1.83 to 1.87, matching the repository CI and target dependency requirements.
+
+### Security
+
+- Keep Windows named pipes local-only by default and apply a configured SDDL security descriptor to every pipe instance.
+- Check Unix socket type and device/inode identity before listener startup and drop cleanup. Stale-socket replacement refuses regular files and live listeners; deployments must still use a trusted parent directory to exclude replacement after the final safe metadata check.
+
+### Internal
+
+- Remove the `interprocess`, `widestring`, and transitive `doctest-file` dependencies.
+- Add real cross-platform IPC integration tests and Criterion transport benchmarks for connection, request, pooling, payload, and concurrent-burst scenarios.
+
 ## [0.4.0] - 2026-04-24
 
 ### Performance

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,12 +272,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "doctest-file"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2db04e74f0a9a93103b50e90b96024c9b2bdca8bce6a632ec71b88736d3d359"
-
-[[package]]
 name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,21 +616,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "interprocess"
-version = "2.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798de1433ba514cc6c04c4144c2469af81396e4906195218737c776d47769572"
-dependencies = [
- "doctest-file",
- "futures-core",
- "libc",
- "recvmsg",
- "tokio",
- "widestring",
- "windows-sys",
-]
-
-[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "kode-bridge"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -673,7 +652,6 @@ dependencies = [
  "futures",
  "http",
  "httparse",
- "interprocess",
  "libc",
  "parking_lot",
  "path-tree",
@@ -689,7 +667,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "widestring",
+ "windows-sys",
 ]
 
 [[package]]
@@ -939,12 +917,6 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "recvmsg"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
@@ -1504,12 +1476,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "widestring"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,12 @@ path = "benches/bench_version.rs"
 harness = false
 required-features = ["full"]
 
+[[bench]]
+name = "ipc_transport"
+path = "benches/ipc_transport.rs"
+harness = false
+required-features = ["full"]
+
 [lints.clippy]
 correctness = { level = "deny", priority = -1 }
 suspicious = { level = "deny", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kode-bridge"
 authors = ["Tunglies"]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "Modern HTTP Over IPC library for Rust with both client and server support (Unix sockets, Windows named pipes)."
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ categories = [
     "api-bindings",
     "asynchronous",
 ]
-rust-version = "1.83"
+rust-version = "1.87"
 
 [features]
 default = ["client"]
@@ -23,7 +23,6 @@ server = ["path-tree"]
 full = ["client", "server"]
 
 [dependencies]
-interprocess = { version = "2.4.3", features = ["tokio"] }
 tokio = { version = "1.53.1", features = [
     "rt",
     "rt-multi-thread",
@@ -32,6 +31,7 @@ tokio = { version = "1.53.1", features = [
     "time",
     "macros",
     "signal",
+    "net",
 ] }
 tokio-stream = { version = "0.1.19", features = ["io-util"] }
 tokio-util = { version = "0.7.19", features = ["codec", "io"] }
@@ -54,7 +54,11 @@ url = "2.5.8"
 libc = "0.2.189"
 
 [target.'cfg(windows)'.dependencies]
-widestring = "1.2.1"
+windows-sys = { version = "0.61.2", features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_Security_Authorization",
+] }
 
 [dev-dependencies]
 dotenvy = "0.15.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,12 @@ path = "benches/ipc_transport.rs"
 harness = false
 required-features = ["full"]
 
+[[bench]]
+name = "hot_path"
+path = "benches/hot_path.rs"
+harness = false
+required-features = ["full"]
+
 [lints.clippy]
 correctness = { level = "deny", priority = -1 }
 suspicious = { level = "deny", priority = -1 }

--- a/Makefile
+++ b/Makefile
@@ -58,9 +58,7 @@ format-check:
 # Run tests with coverage information
 test:
 	@echo "🧪 Running tests..."
-	cargo test --lib --all-features
-	@echo "📊 Running library tests specifically..."
-	cargo test --lib --quiet
+	cargo test --all-features
 
 # Build in release mode with optimization
 build:

--- a/PLATFORM_GUIDE.md
+++ b/PLATFORM_GUIDE.md
@@ -1,208 +1,168 @@
 # kode-bridge Platform Guide
 
-**Complete cross-platform usage guide for HTTP Over IPC with client and server capabilities**
+This guide describes the platform contract for kode-bridge 0.5. The crate uses
+Tokio Unix domain sockets on Unix platforms and Tokio named pipes on Windows.
+The HTTP-over-IPC protocol, pooling, routing, retries, and streaming logic are
+implemented by kode-bridge above that transport layer.
 
-This guide provides comprehensive information for using kode-bridge across Unix/Linux/macOS and Windows systems, including both client and server functionality.
+## Documentation map
 
-## 📚 Documentation Structure
+- [Quick Start](./docs/quick-start.md)
+- [Platform Configuration](./docs/platform-configuration.md)
+- [0.4 to 0.5 Migration](./docs/migration-guide.md)
+- [Server Guide](./SERVER_GUIDE.md)
+- [Server Development Notes](./docs/server-development.md)
+- [Runnable examples](./examples/)
+- [API documentation](https://docs.rs/kode-bridge)
 
-This platform guide is organized into focused sections for easier navigation:
+## Supported platforms
 
-### Quick References
-- **[Quick Start Guide](./docs/quick-start.md)** - Get up and running quickly with examples
-- **[Platform Configuration](./docs/platform-configuration.md)** - Environment setup and configuration
-- **[Migration Guide](./docs/migration-guide.md)** - Modernization and best practices
-- **[Server Development](./docs/server-development.md)** - Complete server development guide
+| Platform | Transport | Endpoint example | Server feature |
+| --- | --- | --- | --- |
+| Linux and other supported Unix systems | Unix domain socket | `/run/my-app/service.sock` | `server` |
+| macOS | Unix domain socket | `/tmp/my-app.sock` | `server` |
+| Windows | Local named pipe | `\\.\pipe\my-app` | `server` |
 
-### Additional Resources
-- **[Server Guide](./SERVER_GUIDE.md)** - Comprehensive server implementation guide
-- **[Examples Directory](./examples/)** - Complete runnable examples
-- **[API Documentation](https://docs.rs/kode-bridge)** - Full API reference
+Rust 1.87 is the minimum supported toolchain for version 0.5.
 
-## 🚀 Overview
-
-kode-bridge provides:
-
-### Client Capabilities (Default Feature)
-- **`IpcHttpClient`**: HTTP-style request/response with fluent API
-- **`IpcStreamClient`**: Real-time streaming for continuous data monitoring
-- **Cross-platform compatibility**: Automatic platform detection
-- **Connection pooling**: Optimized connection management
-- **Type-safe JSON**: Automatic serialization/deserialization
-
-### Server Capabilities (Server Feature)
-- **`IpcHttpServer`**: HTTP server with Express.js-style routing
-- **`IpcStreamServer`**: Real-time streaming server with broadcasting
-- **Middleware support**: Request/response interceptors
-- **Multi-client management**: Connection lifecycle and cleanup
-- **Feature-gated compilation**: Include only what you need
-
-## 🌍 Cross-Platform Support
-
-### Automatic Platform Detection
-```rust
-// Same code works on all platforms
-let client = IpcHttpClient::new("/tmp/service.sock")?;  // Unix
-let client = IpcHttpClient::new(r"\\.\pipe\service")?; // Windows
-```
-
-### Platform-Specific Optimizations
-- **Unix/Linux/macOS**: Unix Domain Sockets with superior performance
-- **Windows**: Named Pipes with native Windows integration
-- **Feature flags**: Compile only client or server functionality as needed
-
-Endpoint paths are validated when a client or server is constructed. Unix endpoints are file-system paths and cannot contain an interior NUL. Windows endpoints must use the named-pipe form `\\HOST\pipe\NAME`, normally `\\.\pipe\NAME` for the local machine.
-
-### Listener Permissions
-
-The existing server builders remain available in 0.5.0:
-
-```rust
-#[cfg(all(unix, not(target_os = "macos")))]
-let server = IpcHttpServer::new("/tmp/service.sock")?
-    .with_listener_mode(0o640);
-
-#[cfg(windows)]
-let server = IpcHttpServer::new(r"\\.\pipe\service")?
-    .with_listener_security_descriptor("D:(A;;GA;;;WD)");
-```
-
-Linux and other supported Unix systems apply the requested mode before listening. macOS continues to report `Unsupported` when a custom listener mode is configured. On Windows, the SDDL descriptor is parsed during builder configuration and applied to every named-pipe instance.
-
-## 🔧 Feature Flags
-
-Configure your `Cargo.toml` based on your needs:
+## Feature flags
 
 ```toml
 [dependencies]
-# Client only (default) - 🔥 Most common setup
+# Client only (default)
 kode-bridge = "0.5"
 
-# Server only - For services that only serve data
+# Server only
 kode-bridge = { version = "0.5", features = ["server"] }
 
-# Both client and server - Full-featured applications
+# Client and server
 kode-bridge = { version = "0.5", features = ["full"] }
 ```
 
-## 📋 Quick Examples
+The `client` and `server` features control the high-level APIs. The transport
+implementation is selected at compile time with `cfg(unix)` or `cfg(windows)`;
+there is no runtime platform switch or alternate runtime backend.
 
-### Client Example
+## Endpoint selection
+
+Use conditional compilation when one program targets multiple platforms:
+
 ```rust
-use kode_bridge::IpcHttpClient;
-use std::time::Duration;
-
-let client = IpcHttpClient::new("/tmp/service.sock")?;
-
-// Modern fluent API
-let response = client
-    .get("/api/status")
-    .timeout(Duration::from_secs(5))
-    .send()
-    .await?;
-
-println!("Status: {}", response.status());
-```
-
-### Server Example  
-```rust
-use kode_bridge::{IpcHttpServer, Router, HttpResponse};
-use serde_json::json;
-
-let router = Router::new()
-    .get("/health", |_| async move {
-        HttpResponse::json(&json!({"status": "healthy"}))
-    });
-
-let mut server = IpcHttpServer::new("/tmp/server.sock")?
-    .router(router);
-
-server.serve().await?;
-```
-
-## 🎯 Use Cases
-
-### Client Applications
-- **Local service communication**: Connect to Clash, Mihomo, proxy services
-- **Real-time monitoring**: Stream traffic data, logs, metrics
-- **System integration**: Replace REST API calls with high-performance IPC
-- **Configuration management**: Dynamic config updates with immediate feedback
-
-### Server Applications  
-- **API services**: HTTP-style endpoints over IPC
-- **Real-time data providers**: Stream metrics, events, logs
-- **System bridges**: Connect different applications via IPC
-- **Service orchestration**: Coordinate multiple local services
-
-## 📊 Performance
-
-### Benchmarks
-```bash
-# Run comprehensive benchmarks
-cargo bench
-
-# View results
-open target/criterion/report/index.html
-```
-
-### Performance Characteristics
-- **Connection pooling**: 95%+ connection reuse on Unix, 90%+ on Windows
-- **Low latency**: Sub-millisecond response times for local IPC
-- **High throughput**: Optimized for both request/response and streaming
-- **Memory efficient**: Automatic backpressure and client management
-
-## 🔗 Integration Patterns
-
-### Environment-Based Configuration
-```rust
-// Automatically adapts to platform
 #[cfg(unix)]
-let path = env::var("CUSTOM_SOCK").unwrap_or("/tmp/service.sock".to_string());
-#[cfg(windows)]  
-let path = env::var("CUSTOM_PIPE").unwrap_or(r"\\.\pipe\service".to_string());
+let endpoint = "/tmp/service.sock";
+
+#[cfg(windows)]
+let endpoint = r"\\.\pipe\service";
+
+let client = kode_bridge::IpcHttpClient::new(endpoint)?;
 ```
 
-### Docker and Containerization
-```dockerfile
-# Unix containers
-VOLUME ["/tmp/ipc"]
-ENV CUSTOM_SOCK=/tmp/ipc/service.sock
+Endpoint rules:
 
-# Windows containers  
-ENV CUSTOM_PIPE=\\.\pipe\service
-```
+- Unix endpoints are file-system paths. Interior NUL bytes are rejected.
+- Windows endpoints must have the form `\\HOST\pipe\NAME`. Use `.` as the
+  host for local pipes: `\\.\pipe\NAME`.
+- Windows servers reject remote clients, so a remote host component is not a
+  supported deployment mode.
+- Validation happens in `Endpoint::new` and in the high-level client/server
+  constructors.
 
-### Service Discovery
+kode-bridge does not automatically read environment variables. The repository
+examples use `CUSTOM_SOCK` and `CUSTOM_PIPE` as application-level conventions.
+
+## Unix listener behavior
+
+The default listener:
+
+- creates a Tokio `UnixListener`;
+- does not overwrite an existing socket path;
+- removes its own socket path when dropped;
+- checks socket type and device/inode identity before cleanup.
+
+For an explicit stale-socket policy:
+
 ```rust
-// Dynamic service discovery
-let services = vec![
-    "/tmp/service1.sock",
-    "/tmp/service2.sock", 
-    "/tmp/service3.sock"
-];
+#[cfg(unix)]
+let options = kode_bridge::ListenerOptions::new()
+    .reclaim_name(true)
+    .try_overwrite(true)
+    .max_spin_time(std::time::Duration::from_millis(100));
 
-for service_path in services {
-    if let Ok(client) = IpcHttpClient::new(service_path) {
-        // Use first available service
-        break;
-    }
-}
+#[cfg(unix)]
+let server = kode_bridge::IpcHttpServer::new("/run/my-app/service.sock")?
+    .with_listener_options(options);
 ```
 
-## 🚀 Getting Started
+`try_overwrite(true)` only removes a path that is still the same stale Unix
+socket after the liveness and identity checks. It refuses normal files and
+live listeners. The final metadata check and file removal cannot be one atomic
+standard-library operation, so use a parent directory that untrusted users
+cannot modify.
 
-1. **Read the [Quick Start Guide](./docs/quick-start.md)** for immediate setup
-2. **Configure your platform** using the [Platform Configuration](./docs/platform-configuration.md) guide
-3. **Explore examples** in the [examples/](./examples/) directory
-4. **For server development**, see the [Server Development](./docs/server-development.md) guide
-5. **Migrating existing code?** Check the [Migration Guide](./docs/migration-guide.md)
+Custom listener mode is applied before listening on supported Unix platforms:
 
-## 🤝 Community and Support
+```rust
+#[cfg(all(unix, not(target_os = "macos")))]
+let server = kode_bridge::IpcHttpServer::new("/run/my-app/service.sock")?
+    .with_listener_mode(0o660);
+```
 
-- **[GitHub Issues](https://github.com/KodeBarinn/kode-bridge/issues)** - Bug reports and feature requests
-- **[GitHub Discussions](https://github.com/KodeBarinn/kode-bridge/discussions)** - Community help and discussions
-- **[Crates.io](https://crates.io/crates/kode-bridge)** - Latest releases and documentation
+Custom mode currently returns `Unsupported` on macOS. Directory ownership and
+permissions remain the primary production access boundary.
 
----
+## Windows listener behavior
 
-**kode-bridge** - Modern HTTP Over IPC for Rust 🚀
+Windows uses Tokio named pipes. The listener keeps a pending next instance so
+concurrent connects do not encounter a handoff gap. Clients retry
+`ERROR_PIPE_BUSY` asynchronously. High-level HTTP and streaming requests wrap
+connection setup in their request timeout. Direct `IpcStream::connect` and
+pool-preheat operations need an application-owned cancellation boundary.
+
+Named pipes reject remote clients. To set a local security descriptor:
+
+```rust
+#[cfg(windows)]
+let server = kode_bridge::IpcHttpServer::new(r"\\.\pipe\service")?
+    .with_listener_security_descriptor("D:(A;;GA;;;WD)");
+```
+
+The descriptor is applied to every pipe instance. Invalid SDDL retains the 0.4
+API behavior and panics during builder configuration. Do not pass unvalidated
+user input as SDDL.
+
+The backend uses 512-byte inbound and outbound pipe buffers and preserves
+flush-on-drop delivery for a final response. These are compatibility details,
+not public tuning knobs.
+
+## Containers and services
+
+For Unix containers, mount a dedicated socket directory and set its ownership
+and mode explicitly. Do not put a privileged service socket in a world-writable
+directory.
+
+Windows container named-pipe access depends on the container host and service
+configuration. kode-bridge validates and opens the pipe but does not configure
+container isolation or Windows service identities.
+
+## Performance evidence
+
+Run both benchmark suites with the required features:
+
+```bash
+cargo bench --all-features --bench bench_version
+cargo bench --all-features --bench ipc_transport
+```
+
+`bench_version` covers builders, codec/router work, and in-memory duplex paths.
+`ipc_transport` covers real cold connections, direct and pooled requests,
+payload sizes, and a concurrent burst. Compare results only on the same host,
+platform, toolchain, build mode, and benchmark parameters. No fixed connection
+reuse percentage or cross-platform performance ratio is guaranteed.
+
+## Platform acceptance
+
+Compilation for a target is not runtime acceptance. Changes to transport,
+permissions, or cleanup should be exercised on real Linux, macOS, and Windows
+runners. A normal GitHub Windows runner does not prove communication between a
+privileged service and a standard-user client; validate that identity boundary
+in the intended deployment environment.

--- a/PLATFORM_GUIDE.md
+++ b/PLATFORM_GUIDE.md
@@ -51,6 +51,24 @@ let client = IpcHttpClient::new(r"\\.\pipe\service")?; // Windows
 - **Windows**: Named Pipes with native Windows integration
 - **Feature flags**: Compile only client or server functionality as needed
 
+Endpoint paths are validated when a client or server is constructed. Unix endpoints are file-system paths and cannot contain an interior NUL. Windows endpoints must use the named-pipe form `\\HOST\pipe\NAME`, normally `\\.\pipe\NAME` for the local machine.
+
+### Listener Permissions
+
+The existing server builders remain available in 0.5.0:
+
+```rust
+#[cfg(all(unix, not(target_os = "macos")))]
+let server = IpcHttpServer::new("/tmp/service.sock")?
+    .with_listener_mode(0o640);
+
+#[cfg(windows)]
+let server = IpcHttpServer::new(r"\\.\pipe\service")?
+    .with_listener_security_descriptor("D:(A;;GA;;;WD)");
+```
+
+Linux and other supported Unix systems apply the requested mode before listening. macOS continues to report `Unsupported` when a custom listener mode is configured. On Windows, the SDDL descriptor is parsed during builder configuration and applied to every named-pipe instance.
+
 ## 🔧 Feature Flags
 
 Configure your `Cargo.toml` based on your needs:
@@ -58,13 +76,13 @@ Configure your `Cargo.toml` based on your needs:
 ```toml
 [dependencies]
 # Client only (default) - 🔥 Most common setup
-kode-bridge = "0.1"
+kode-bridge = "0.5"
 
 # Server only - For services that only serve data
-kode-bridge = { version = "0.1", features = ["server"] }
+kode-bridge = { version = "0.5", features = ["server"] }
 
 # Both client and server - Full-featured applications
-kode-bridge = { version = "0.1", features = ["full"] }
+kode-bridge = { version = "0.5", features = ["full"] }
 ```
 
 ## 📋 Quick Examples

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - **💎 Fluent API**: Reqwest-inspired method chaining with type-safe JSON handling
 - **📦 Auto Serialization**: Built-in JSON request and response processing
 - **⚡ High Performance**: Optimized connection management strategies for different platforms
-- **🔧 Easy Integration**: Based on [interprocess](https://github.com/kotauskas/interprocess) and Tokio async runtime
+- **🔧 Easy Integration**: Thin transport layer built directly on Tokio's Unix sockets and Windows named pipes
 - **🔄 Backward Compatible**: Old API methods still work alongside new fluent interface
 - **📖 Complete Support**: Includes examples, benchmarks, and comprehensive documentation
 
@@ -30,13 +30,13 @@
 ```toml
 [dependencies]
 # Client only (default)
-kode-bridge = "0.1"
+kode-bridge = "0.5"
 
 # Server only  
-kode-bridge = { version = "0.1", features = ["server"] }
+kode-bridge = { version = "0.5", features = ["server"] }
 
 # Both client and server
-kode-bridge = { version = "0.1", features = ["full"] }
+kode-bridge = { version = "0.5", features = ["full"] }
 
 # Required runtime
 tokio = { version = "1", features = ["full"] }
@@ -283,8 +283,8 @@ Benchmarks automatically:
 │            http_client.rs               │   http_server.rs        │
 │        (HTTP Protocol Handler)          │  (HTTP Protocol Server) │
 ├─────────────────────────────────────────┴─────────────────────────┤
-│                    interprocess                              │
-│                (Cross-Platform IPC Transport)                    │
+│              kode-bridge transport adapter                      │
+│               (Tokio native IPC transport)                      │
 ├─────────────────┬───────────────────────┬─────────────────────────┤
 │   Unix Sockets  │    Windows Pipes      │   Feature Flags         │
 │   (Unix/Linux)  │     (Windows)         │ (client/server/full)    │

--- a/SERVER_GUIDE.md
+++ b/SERVER_GUIDE.md
@@ -1,467 +1,234 @@
 # kode-bridge Server Guide
 
-**Complete guide for building HTTP Over IPC servers**
-
-This guide explains how to use kode-bridge's server functionality to create high-performance IPC servers that handle HTTP-style requests and real-time streaming.
-
-## 🚀 Quick Start
-
-### Enable Server Features
-
-Add to your `Cargo.toml`:
+This guide covers the server APIs available in kode-bridge 0.5. Enable the
+`server` feature for server-only programs or `full` when the same crate also
+uses client APIs.
 
 ```toml
 [dependencies]
 kode-bridge = { version = "0.5", features = ["server"] }
-# Or for both client and server
-kode-bridge = { version = "0.5", features = ["full"] }
-
-# Required dependencies for examples
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-tracing-subscriber = "0.3"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal"] }
+serde_json = "1"
+http = "1"
 ```
 
-### Available Features
+Rust 1.87 or newer is required.
 
-- `client` (default) - Enables IPC client functionality
-- `server` - Enables IPC server functionality  
-- `full` - Enables both client and server
+## HTTP server
 
-## 🌐 HTTP IPC Server
-
-### Basic HTTP Server
+`IpcHttpServer` parses HTTP-style requests from an IPC connection, routes them
+by method and path, and encodes an HTTP-style response on the same connection.
 
 ```rust
-use kode_bridge::{IpcHttpServer, Router, HttpResponse, ServerConfig, Result};
+use http::StatusCode;
+use kode_bridge::{HttpResponse, IpcHttpServer, Result, Router};
 use serde_json::json;
-use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Configure server
-    let config = ServerConfig {
-        max_connections: 100,
-        read_timeout: Duration::from_secs(30),
-        write_timeout: Duration::from_secs(30),
-        max_request_size: 1024 * 1024, // 1MB
-        enable_logging: true,
-        shutdown_timeout: Duration::from_secs(5),
-    };
+    #[cfg(unix)]
+    let endpoint = "/tmp/kode-bridge-server.sock";
+    #[cfg(windows)]
+    let endpoint = r"\\.\pipe\kode-bridge-server";
 
-    // Create router with endpoints
     let router = Router::new()
-        .get("/health", |_ctx| async move {
+        .get("/health", |_| async {
             HttpResponse::json(&json!({"status": "healthy"}))
         })
-        .post("/api/data", |ctx| async move {
+        .get("/users/:id", |ctx| async move {
+            let id = ctx
+                .path_params
+                .get("id")
+                .cloned()
+                .unwrap_or_default();
+            HttpResponse::json(&json!({"id": id}))
+        })
+        .post("/echo", |ctx| async move {
             match ctx.json::<serde_json::Value>() {
-                Ok(data) => {
-                    println!("Received: {}", data);
-                    HttpResponse::json(&json!({"received": data}))
-                }
-                Err(e) => Ok(HttpResponse::builder()
-                    .status(http::StatusCode::BAD_REQUEST)
-                    .json(&json!({"error": e.to_string()}))?
-                    .build())
+                Ok(value) => HttpResponse::json(&value),
+                Err(error) => Ok(HttpResponse::error(
+                    StatusCode::BAD_REQUEST,
+                    &error.to_string(),
+                )),
             }
         });
 
-    // Start server
-    let mut server = IpcHttpServer::with_config("/tmp/my_server.sock", config)?
-        .router(router);
-    
+    let mut server = IpcHttpServer::new(endpoint)?.router(router);
     server.serve().await
 }
 ```
 
-### HTTP Server Features
+The router supports GET, POST, PUT, and DELETE helpers. Use `add_route` with an
+`http::Method` for another method. Route parameters use `:name`, for example
+`/users/:id`.
 
-#### Request Context
+The current router does not provide middleware or static-file helpers. Put
+cross-cutting behavior in handler functions or an application-owned wrapper.
+
+## Request and response APIs
+
+`RequestContext` exposes:
+
+- `method`, `uri`, `headers`, and raw `body` fields;
+- `json::<T>()` and `text()` body parsing;
+- `query_params()` for decoded query pairs;
+- `path_params` and `path_params()` for route captures;
+- connection ID and timing through `client_info` and `timestamp`.
+
+Handlers return `kode_bridge::Result<HttpResponse>`. Responses can be built
+with `HttpResponse::json`, `HttpResponse::text`, `HttpResponse::error`, or the
+response builder:
+
 ```rust
-use kode_bridge::RequestContext;
-
-// Handler function receives RequestContext
-let handler = |ctx: RequestContext| async move {
-    // Access request details
-    println!("Method: {}", ctx.method);
-    println!("URI: {}", ctx.uri);
-    println!("Headers: {:?}", ctx.headers);
-    
-    // Parse JSON body
-    if let Ok(data) = ctx.json::<MyStruct>() {
-        // Process data
-    }
-    
-    // Get query parameters
-    let params = ctx.query_params();
-    
-    // Get body as text
-    let text = ctx.text()?;
-    
-    HttpResponse::ok()
-};
-```
-
-#### Response Building
-```rust
-use kode_bridge::{HttpResponse, ResponseBuilder};
-use http::StatusCode;
-
-// Simple responses
-let response = HttpResponse::ok();
-let response = HttpResponse::not_found();
-let response = HttpResponse::internal_error();
-
-// JSON responses
-let response = HttpResponse::json(&json!({"key": "value"}))?;
-
-// Custom responses
 let response = HttpResponse::builder()
-    .status(StatusCode::CREATED)
+    .status(http::StatusCode::CREATED)
     .header("content-type", "application/json")
-    .json(&data)?
+    .json(&serde_json::json!({"created": true}))?
     .build();
-
-// Text responses
-let response = HttpResponse::text("Hello, World!");
-
-// Error responses
-let response = HttpResponse::error(StatusCode::BAD_REQUEST, "Invalid input");
 ```
 
-#### Routing
-```rust
-use kode_bridge::Router;
+## HTTP server configuration
 
-let router = Router::new()
-    // HTTP methods
-    .get("/users", get_users)
-    .post("/users", create_user)
-    .put("/users/{id}", update_user)  // Path parameters coming soon
-    .delete("/users/{id}", delete_user)
-    
-    // Async closures
-    .get("/status", |_| async { HttpResponse::text("OK") })
-    
-    // Complex handlers
-    .post("/upload", |ctx| async move {
-        let body_size = ctx.body.len();
-        if body_size > 1024 * 1024 {
-            return Ok(HttpResponse::error(
-                StatusCode::PAYLOAD_TOO_LARGE, 
-                "File too large"
-            ));
-        }
-        
-        // Process upload
-        HttpResponse::json(&json!({
-            "uploaded": true,
-            "size": body_size
-        }))
-    });
-```
-
-#### Server Configuration
 ```rust
 use kode_bridge::ServerConfig;
 use std::time::Duration;
 
 let config = ServerConfig {
-    // Connection limits
-    max_connections: 200,
-    
-    // Timeouts
-    read_timeout: Duration::from_secs(30),
-    write_timeout: Duration::from_secs(30),
-    shutdown_timeout: Duration::from_secs(10),
-    
-    // Limits
-    max_request_size: 5 * 1024 * 1024, // 5MB
-    
-    // Logging
+    max_connections: 128,
+    read_timeout: Duration::from_secs(5),
+    write_timeout: Duration::from_secs(5),
+    max_request_size: 10 * 1024 * 1024,
+    max_header_size: 4096,
     enable_logging: true,
+    max_requests_per_connection: 32,
+    shutdown_timeout: Duration::from_secs(3),
 };
 ```
 
-#### Server Statistics
+Create the server with `IpcHttpServer::with_config(endpoint, config)`.
+
+- `max_connections` bounds concurrently accepted connections.
+- `read_timeout` bounds waiting for and parsing the next request.
+- Despite its name, `write_timeout` currently bounds the handler future. The
+  subsequent `framed.send(response)` is not wrapped in a separate timeout.
+- `max_requests_per_connection` bounds keep-alive reuse on one connection.
+- Size limits should be set from the largest supported request, with overhead.
+- `enable_logging` controls per-request server logging.
+
+`ServerStats` reports connections, requests, responses, errors, and start time.
+The server does not currently expose a cloneable runtime stats/control handle;
+plan ownership before moving the server into a task.
+
+## Streaming server
+
+`IpcStreamServer` broadcasts raw `StreamMessage` frames. JSON and text messages
+are newline-delimited; binary messages are written as provided. A periodic
+`JsonDataSource` is the shortest supported setup:
+
 ```rust
-// Get server statistics
-let stats = server.stats();
-println!("Connections: {}", stats.total_connections);
-println!("Active: {}", stats.active_connections);  
-println!("Requests: {}", stats.total_requests);
-println!("Uptime: {:?}", stats.started_at.elapsed());
-```
-
-## 🌊 Streaming IPC Server
-
-### Basic Streaming Server
-
-```rust
-use kode_bridge::{
-    IpcStreamServer, StreamMessage, StreamServerConfig, 
-    JsonDataSource, Result
-};
+use kode_bridge::{IpcStreamServer, JsonDataSource, Result, StreamServerConfig};
 use serde_json::json;
 use std::time::Duration;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Configure streaming server
+    #[cfg(unix)]
+    let endpoint = "/tmp/kode-bridge-stream.sock";
+    #[cfg(windows)]
+    let endpoint = r"\\.\pipe\kode-bridge-stream";
+
     let config = StreamServerConfig {
-        max_connections: 500,
-        buffer_size: 65536,
-        write_timeout: Duration::from_secs(10),
+        max_connections: 64,
+        buffer_size: 64 * 1024,
+        write_timeout: Duration::from_secs(5),
+        max_message_size: 1024 * 1024,
+        enable_logging: true,
+        shutdown_timeout: Duration::from_secs(5),
         broadcast_capacity: 1000,
         keepalive_interval: Duration::from_secs(30),
-        ..Default::default()
     };
 
-    // Create data source that generates data every 2 seconds
-    let data_source = JsonDataSource::new(
-        || {
-            Ok(json!({
-                "timestamp": chrono::Utc::now().timestamp(),
-                "data": rand::random::<f64>(),
-                "status": "active"
-            }))
-        },
-        Duration::from_secs(2)
+    let source = JsonDataSource::new(
+        || Ok(json!({"status": "running"})),
+        Duration::from_secs(1),
     );
 
-    // Create and start server
-    let mut server = IpcStreamServer::with_config("/tmp/stream_server.sock", config)?;
-    server.serve_with_source(data_source).await
+    let mut server = IpcStreamServer::with_config(endpoint, config)?;
+    server.serve_with_source(source).await
 }
 ```
 
-### Streaming Features
+For application-defined production logic, implement `StreamSource` directly.
+It supplies `next_messages`, `has_more`, `initialize`, and `cleanup`; see
+[stream_server.rs](./examples/stream_server.rs) and the API documentation for
+the exact signatures.
 
-#### Message Types
+`IpcStreamClient` is not the direct client for `IpcStreamServer` in 0.5. The
+former parses an HTTP-style streamed response, while the latter emits raw
+newline-delimited frames. Use a raw Tokio `AsyncRead` client for the stream
+server protocol, or expose an HTTP-style streaming handler for
+`IpcStreamClient`.
+
+The public `broadcast()` method requires the server's broadcast channel to be
+initialized, but `serve(&mut self)` holds the mutable server borrow. Version
+0.5 does not expose a cloneable broadcast/control handle, so
+`serve_with_source` is the practical public API for ongoing broadcasts.
+
+## Listener permissions and cleanup
+
+### Unix
+
 ```rust
-use kode_bridge::StreamMessage;
-
-// JSON messages
-let msg = StreamMessage::json(&json!({"type": "data", "value": 42}))?;
-
-// Text messages  
-let msg = StreamMessage::text("Hello, streaming clients!");
-
-// Binary messages
-let msg = StreamMessage::binary(vec![0x01, 0x02, 0x03]);
-
-// Keep-alive ping
-let msg = StreamMessage::Ping;
-
-// Server shutdown notification
-let msg = StreamMessage::Close;
+#[cfg(all(unix, not(target_os = "macos")))]
+let server = IpcHttpServer::new("/run/my-app/service.sock")?
+    .with_listener_mode(0o660);
 ```
 
-#### Manual Broadcasting
-```rust
-// Start server without automatic data source
-let mut server = IpcStreamServer::new("/tmp/stream.sock")?;
-
-// Start server in background
-tokio::spawn(async move {
-    server.serve().await
-});
-
-// Broadcast messages manually
-server.broadcast(StreamMessage::text("Manual message"))?;
-server.broadcast(StreamMessage::json(&json!({"event": "update"}))?)?;
-```
-
-#### Custom Data Sources
-```rust
-use kode_bridge::{StreamSource, StreamMessage, Result};
-use std::pin::Pin;
-use std::future::Future;
-
-struct CustomDataSource {
-    counter: u64,
-}
-
-impl StreamSource for CustomDataSource {
-    fn next_messages(&mut self) -> Pin<Box<dyn Future<Output = Result<Vec<StreamMessage>>> + Send + '_>> {
-        Box::pin(async move {
-            self.counter += 1;
-            let message = StreamMessage::json(&json!({
-                "counter": self.counter,
-                "timestamp": chrono::Utc::now().timestamp()
-            }))?;
-            Ok(vec![message])
-        })
-    }
-
-    fn has_more(&self) -> bool {
-        true // Always generate more data
-    }
-
-    fn initialize(&mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
-        Box::pin(async move {
-            println!("Data source initialized");
-            Ok(())
-        })
-    }
-
-    fn cleanup(&mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
-        Box::pin(async move {
-            println!("Data source cleaned up");
-            Ok(())
-        })
-    }
-}
-```
-
-#### Client Management
-```rust
-// Get connected clients
-let clients = server.clients();
-for client in clients {
-    println!("Client {}: {} messages sent", 
-             client.client_id, client.messages_sent);
-}
-
-// Get server statistics
-let stats = server.stats();
-println!("Streaming stats: {}", stats);
-println!("Messages/sec: {:.1}", stats.messages_per_second);
-```
-
-## 🔧 Cross-Platform Usage
-
-### Unix/Linux/macOS
-```bash
-# Start HTTP server
-cargo run --features=server --example http_server
-
-# Test with client
-CUSTOM_SOCK=/tmp/my_server.sock cargo run --features=client --example request
-```
+The default listener removes its own socket path when dropped. It does not
+overwrite a stale path unless `ListenerOptions::try_overwrite(true)` is set.
+Use a trusted parent directory. Custom mode is currently unsupported on macOS.
 
 ### Windows
-```cmd
-REM Start HTTP server  
-cargo run --features=server --example http_server
 
-REM Test with client
-set CUSTOM_PIPE=\\.\pipe\my_server
-cargo run --features=client --example request
-```
-
-## 🎯 Production Deployment
-
-### Error Handling
 ```rust
-use kode_bridge::{HttpResponse, KodeBridgeError};
-use http::StatusCode;
-
-let handler = |ctx| async move {
-    match process_request(ctx).await {
-        Ok(result) => HttpResponse::json(&result),
-        Err(e) => {
-            tracing::error!("Request failed: {}", e);
-            
-            let status = if e.to_string().contains("validation") {
-                StatusCode::BAD_REQUEST
-            } else {
-                StatusCode::INTERNAL_SERVER_ERROR
-            };
-            
-            Ok(HttpResponse::error(status, "Request failed"))
-        }
-    }
-};
+#[cfg(windows)]
+let server = IpcHttpServer::new(r"\\.\pipe\my-app")?
+    .with_listener_security_descriptor("D:(A;;GA;;;WD)");
 ```
 
-### Graceful Shutdown
+Windows named pipes reject remote clients. SDDL is applied to every pipe
+instance; invalid SDDL panics during builder configuration for 0.4 API
+compatibility. Use a least-privilege descriptor for production services.
+
+## Task lifecycle
+
+`serve()` runs until it is cancelled or its internal shutdown channel fires;
+accept errors are logged and the accept loop continues. Version 0.5 does not
+expose a separate shutdown handle. When the application owns the server task,
+cancellation is the usable external shutdown mechanism:
+
 ```rust
-use tokio::signal;
-
-// Start server in background
-let mut server = IpcHttpServer::new("/tmp/server.sock")?;
-let server_task = tokio::spawn(async move {
-    server.serve().await
-});
-
-// Wait for shutdown signal
-signal::ctrl_c().await?;
-println!("Shutting down server...");
-
-// Stop server
-server_task.abort();
-
-// Wait for cleanup
-tokio::time::sleep(Duration::from_millis(500)).await;
-println!("Server stopped");
+let task = tokio::spawn(async move { server.serve().await });
+tokio::signal::ctrl_c().await?;
+task.abort();
+let _ = task.await;
 ```
 
-### Monitoring and Metrics
-```rust
-// Periodic stats reporting
-tokio::spawn(async move {
-    let mut interval = tokio::time::interval(Duration::from_secs(60));
-    loop {
-        interval.tick().await;
-        let stats = server.stats();
-        tracing::info!("Server stats: {}", stats);
-        
-        // Send to monitoring system
-        send_metrics(&stats).await;
-    }
-});
-```
+Await the cancelled task so the listener is dropped before restarting on the
+same endpoint. On Unix, that drop performs identity-checked path cleanup.
 
-## 📊 Performance Tips
+## Performance guidance
 
-### HTTP Server Optimization
-- Use connection pooling on the client side
-- Configure appropriate timeouts
-- Limit request sizes to prevent memory issues
-- Enable request logging only in development
+- Reuse pooled client connections instead of increasing server limits first.
+- Set `max_connections` and broadcast capacity from measured concurrency and
+  per-connection memory.
+- Keep request and message limits explicit.
+- Do not shorten `write_timeout` below the slowest supported handler. Treat a
+  response-write deadline as an open server limitation in version 0.5.
+- Run `cargo bench --all-features --bench ipc_transport` for transport changes.
+- Treat shared CI runners as functional evidence, not stable performance data.
 
-### Streaming Server Optimization  
-- Adjust buffer sizes based on message frequency
-- Use appropriate broadcast channel capacity
-- Implement backpressure for slow clients
-- Monitor client lag and disconnect slow clients
-
-### General Tips
-- Use `tracing` for structured logging
-- Monitor connection counts and memory usage
-- Implement health check endpoints
-- Use appropriate IPC paths (`/var/run` for production on Unix)
-
-## 🔍 Debugging
-
-### Enable Detailed Logging
-```rust
-// Add to Cargo.toml dev-dependencies
-tracing-subscriber = "0.3"
-
-// In your main function
-tracing_subscriber::fmt()
-    .with_max_level(tracing::Level::DEBUG)
-    .init();
-```
-
-### Common Issues
-- **Permission denied**: Check socket file permissions
-- **Address already in use**: Ensure socket file is cleaned up
-- **Connection refused**: Verify server is running and path is correct
-- **Message too large**: Check `max_request_size` and `max_message_size`
-
-## 📚 Examples
-
-See the `examples/` directory for complete working examples:
-
-- `examples/http_server.rs` - Full HTTP server with routing
-- `examples/stream_server.rs` - Real-time streaming server
-- Run with: `cargo run --features=server --example http_server`
-
----
-
-**kode-bridge** - Modern HTTP Over IPC for Rust 🚀
+Complete runnable programs are maintained in
+[http_server.rs](./examples/http_server.rs),
+[stream_server.rs](./examples/stream_server.rs), and
+[server.rs](./examples/server.rs).

--- a/SERVER_GUIDE.md
+++ b/SERVER_GUIDE.md
@@ -12,9 +12,9 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-kode-bridge = { version = "0.1", features = ["server"] }
+kode-bridge = { version = "0.5", features = ["server"] }
 # Or for both client and server
-kode-bridge = { version = "0.1", features = ["full"] }
+kode-bridge = { version = "0.5", features = ["full"] }
 
 # Required dependencies for examples
 tokio = { version = "1", features = ["full"] }

--- a/benches/hot_path.rs
+++ b/benches/hot_path.rs
@@ -336,16 +336,16 @@ impl StreamBroadcastContext {
                 .send(StreamMessage::text(STREAM_WARMUP))
                 .await
                 .unwrap_or_else(|error| panic!("failed to publish stream warmup: {error}"));
-            while let Ok(event) = self.events.try_recv() {
-                if matches!(event, StreamEvent::Warmed) {
-                    warmed += 1;
-                }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if let Ok(Some(StreamEvent::Warmed)) =
+                timeout(Duration::from_millis(25).min(remaining), self.events.recv()).await
+            {
+                warmed += 1;
             }
             assert!(
                 Instant::now() < deadline,
                 "streaming benchmark clients did not subscribe in time"
             );
-            tokio::task::yield_now().await;
         }
     }
 
@@ -492,17 +492,18 @@ fn bench_stream_broadcast(c: &mut Criterion, context: &HttpBenchContext) {
             BenchmarkId::new("broadcast_write_flush", clients),
             &clients,
             |bencher, &clients| {
-                let endpoint = unique_endpoint("stream");
-                let broadcast = Arc::new(Mutex::new(
-                    context
-                        .runtime
-                        .block_on(StreamBroadcastContext::start(endpoint, clients)),
-                ));
-                bencher.to_async(&context.runtime).iter(|| {
-                    let broadcast = Arc::clone(&broadcast);
-                    async move {
-                        broadcast.lock().await.broadcast_once(clients).await;
-                    }
+                bencher.iter_custom(|iterations| {
+                    context.runtime.block_on(async {
+                        let endpoint = unique_endpoint("stream");
+                        let mut broadcast = StreamBroadcastContext::start(endpoint, clients).await;
+                        let started = Instant::now();
+                        for _ in 0..iterations {
+                            broadcast.broadcast_once(clients).await;
+                        }
+                        let elapsed = started.elapsed();
+                        drop(broadcast);
+                        elapsed
+                    })
                 });
             },
         );

--- a/benches/hot_path.rs
+++ b/benches/hot_path.rs
@@ -1,0 +1,546 @@
+#![allow(clippy::panic)]
+
+use bytes::Bytes;
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use futures::future::join_all;
+use http::Method;
+use kode_bridge::ipc_http_client::{ClientConfig, IpcHttpClient};
+use kode_bridge::ipc_http_server::{HttpResponse, IpcHttpServer, Router, ServerConfig};
+use kode_bridge::ipc_stream_server::{IpcStreamServer, StreamServerConfig, StreamSource};
+use kode_bridge::metrics::MetricsCollector;
+use kode_bridge::pool::PoolConfig;
+use kode_bridge::retry::{JitterStrategy, RetryConfig, RetryExecutor};
+use kode_bridge::{KodeBridgeError, Result, StreamMessage};
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _, BufReader};
+use tokio::runtime::Runtime;
+use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::task::JoinHandle;
+use tokio::time::{timeout, Instant};
+
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(3);
+const MAX_POOL_SIZE: usize = 40;
+static ENDPOINT_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+struct HttpBenchContext {
+    runtime: Runtime,
+    endpoint: PathBuf,
+    server_task: Option<JoinHandle<kode_bridge::Result<()>>>,
+    client: IpcHttpClient,
+    router: Router,
+}
+
+impl HttpBenchContext {
+    fn new() -> Self {
+        let runtime = Runtime::new().unwrap_or_else(|error| panic!("failed to create benchmark runtime: {error}"));
+        let endpoint = unique_endpoint("http");
+        let router = benchmark_router();
+        let server = IpcHttpServer::with_config(&endpoint, server_config())
+            .unwrap_or_else(|error| panic!("failed to configure benchmark server: {error}"))
+            .router(router.clone());
+        let server_task = runtime.spawn(async move {
+            let mut server = server;
+            server.serve().await
+        });
+        runtime.block_on(wait_until_ready(&endpoint, &server_task));
+        let client = build_client(&endpoint, true);
+        Self {
+            runtime,
+            endpoint,
+            server_task: Some(server_task),
+            client,
+            router,
+        }
+    }
+}
+
+impl Drop for HttpBenchContext {
+    fn drop(&mut self) {
+        self.client.close();
+        if let Some(task) = self.server_task.take() {
+            task.abort();
+            let result = self.runtime.block_on(task);
+            assert!(result.is_err_and(|error| error.is_cancelled()));
+        }
+    }
+}
+
+fn unique_endpoint(label: &str) -> PathBuf {
+    let sequence = ENDPOINT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+
+    #[cfg(unix)]
+    {
+        PathBuf::from(format!(
+            "/tmp/kb-hot-path-{}-{sequence}-{label}.sock",
+            std::process::id()
+        ))
+    }
+
+    #[cfg(windows)]
+    {
+        PathBuf::from(format!(
+            r"\\.\pipe\kb-hot-path-{}-{sequence}-{label}",
+            std::process::id()
+        ))
+    }
+}
+
+const fn server_config() -> ServerConfig {
+    ServerConfig {
+        max_connections: MAX_POOL_SIZE + 8,
+        read_timeout: REQUEST_TIMEOUT,
+        write_timeout: REQUEST_TIMEOUT,
+        max_request_size: 2 * 1024 * 1024,
+        max_header_size: 16 * 1024,
+        enable_logging: false,
+        max_requests_per_connection: usize::MAX,
+        shutdown_timeout: Duration::from_secs(1),
+    }
+}
+
+const fn client_config(enable_pooling: bool) -> ClientConfig {
+    ClientConfig {
+        default_timeout: REQUEST_TIMEOUT,
+        pool_config: PoolConfig {
+            max_size: MAX_POOL_SIZE,
+            min_idle: 0,
+            max_idle_time_ms: 30_000,
+            connection_timeout_ms: 1_000,
+            retry_delay_ms: 5,
+            max_retries: 1,
+            max_concurrent_requests: MAX_POOL_SIZE,
+            max_requests_per_second: None,
+        },
+        enable_pooling,
+        max_retries: 1,
+        retry_delay: Duration::from_millis(5),
+        max_concurrent_requests: MAX_POOL_SIZE,
+        max_requests_per_second: None,
+    }
+}
+
+fn build_client(path: &Path, enable_pooling: bool) -> IpcHttpClient {
+    IpcHttpClient::with_config(path, client_config(enable_pooling))
+        .unwrap_or_else(|error| panic!("failed to create benchmark client: {error}"))
+}
+
+fn benchmark_router() -> Router {
+    Router::new()
+        .get("/ready", |_ctx| async { Ok(HttpResponse::text("ready")) })
+        .get("/literal", |_ctx| async { Ok(HttpResponse::text("literal")) })
+        .get("/items/:id", |ctx| async move {
+            Ok(HttpResponse::text(ctx.path_params["id"].clone()))
+        })
+        .get("/query", |ctx| async move {
+            Ok(HttpResponse::text(
+                ctx.query_params().get("page").cloned().unwrap_or_default(),
+            ))
+        })
+        .get("/response", |_ctx| async {
+            Ok(HttpResponse::builder()
+                .header("content-type", "application/json")
+                .body(Bytes::from_static(b"{\"status\":\"ok\",\"items\":[1,2,3]}"))
+                .build())
+        })
+        .get("/fragmented", |_ctx| async { Ok(HttpResponse::text("fragmented")) })
+}
+
+async fn wait_until_ready(endpoint: &Path, server_task: &JoinHandle<kode_bridge::Result<()>>) {
+    let deadline = Instant::now() + STARTUP_TIMEOUT;
+    loop {
+        assert!(!server_task.is_finished(), "benchmark server exited before readiness");
+        let client = build_client(endpoint, false);
+        if let Ok(Ok(response)) = timeout(Duration::from_millis(250), client.get("/ready").send()).await {
+            if response.is_success() {
+                return;
+            }
+        }
+        assert!(Instant::now() < deadline, "benchmark server readiness timed out");
+        tokio::task::yield_now().await;
+    }
+}
+
+#[cfg(unix)]
+type RawStream = tokio::net::UnixStream;
+#[cfg(windows)]
+type RawStream = tokio::net::windows::named_pipe::NamedPipeClient;
+
+#[cfg(unix)]
+async fn raw_connect(path: &Path) -> std::io::Result<RawStream> {
+    RawStream::connect(path).await
+}
+
+#[cfg(windows)]
+async fn raw_connect(path: &Path) -> std::io::Result<RawStream> {
+    tokio::net::windows::named_pipe::ClientOptions::new().open(path)
+}
+
+async fn fragmented_request(endpoint: &Path) {
+    let mut stream = raw_connect(endpoint)
+        .await
+        .unwrap_or_else(|error| panic!("failed to create fragmented-header client: {error}"));
+    stream
+        .write_all(b"GET /fragmented HTTP/1.1\r\nHost: benchmark")
+        .await
+        .unwrap_or_else(|error| panic!("failed to write initial header fragment: {error}"));
+    stream
+        .write_all(b"\r\n\r\n")
+        .await
+        .unwrap_or_else(|error| panic!("failed to write header terminator: {error}"));
+    stream
+        .flush()
+        .await
+        .unwrap_or_else(|error| panic!("failed to flush fragmented request: {error}"));
+    let mut response = [0u8; 128];
+    let bytes_read = timeout(REQUEST_TIMEOUT, stream.read(&mut response))
+        .await
+        .unwrap_or_else(|_| panic!("fragmented-header response timed out"))
+        .unwrap_or_else(|error| panic!("failed to read fragmented-header response: {error}"));
+    assert!(response[..bytes_read].starts_with(b"HTTP/1.1 200"));
+}
+
+const STREAM_WARMUP: &str = "warmup";
+const STREAM_PAYLOAD: &str = "payload";
+
+struct ControlledSource {
+    messages: Arc<Mutex<mpsc::Receiver<StreamMessage>>>,
+    initialized: Arc<std::sync::Mutex<Option<oneshot::Sender<()>>>>,
+}
+
+impl StreamSource for ControlledSource {
+    fn next_messages(&mut self) -> Pin<Box<dyn Future<Output = Result<Vec<StreamMessage>>> + Send + '_>> {
+        Box::pin(async move {
+            let mut messages = self.messages.lock().await;
+            Ok(messages.recv().await.into_iter().collect())
+        })
+    }
+
+    fn has_more(&self) -> bool {
+        true
+    }
+
+    fn initialize(&mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+        Box::pin(async move {
+            if let Some(ready) = self
+                .initialized
+                .lock()
+                .expect("source readiness lock poisoned")
+                .take()
+            {
+                let _ = ready.send(());
+            }
+            Ok(())
+        })
+    }
+
+    fn cleanup(&mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+enum StreamEvent {
+    Warmed,
+    ReceivedPayload,
+}
+
+struct StreamBroadcastContext {
+    sender: mpsc::Sender<StreamMessage>,
+    events: mpsc::Receiver<StreamEvent>,
+    client_tasks: Vec<JoinHandle<()>>,
+    server_task: JoinHandle<kode_bridge::Result<()>>,
+}
+
+impl StreamBroadcastContext {
+    async fn start(endpoint: PathBuf, clients: usize) -> Self {
+        let (message_tx, message_rx) = mpsc::channel(128);
+        let (source_ready_tx, source_ready_rx) = oneshot::channel();
+        let source = ControlledSource {
+            messages: Arc::new(Mutex::new(message_rx)),
+            initialized: Arc::new(std::sync::Mutex::new(Some(source_ready_tx))),
+        };
+        let mut server = IpcStreamServer::with_config(
+            &endpoint,
+            StreamServerConfig {
+                max_connections: clients + 4,
+                buffer_size: 8192,
+                write_timeout: REQUEST_TIMEOUT,
+                max_message_size: 64 * 1024,
+                enable_logging: false,
+                shutdown_timeout: Duration::from_secs(1),
+                broadcast_capacity: 128,
+                keepalive_interval: Duration::from_secs(60),
+            },
+        )
+        .unwrap_or_else(|error| panic!("failed to configure streaming benchmark server: {error}"));
+        let server_task = tokio::spawn(async move { server.serve_with_source(source).await });
+        timeout(STARTUP_TIMEOUT, source_ready_rx)
+            .await
+            .unwrap_or_else(|_| panic!("streaming benchmark server readiness timed out"))
+            .unwrap_or_else(|_| panic!("streaming benchmark server dropped readiness signal"));
+
+        let (event_tx, event_rx) = mpsc::channel(clients * 4);
+        let mut client_tasks = Vec::with_capacity(clients);
+        for _ in 0..clients {
+            let endpoint = endpoint.clone();
+            let event_tx = event_tx.clone();
+            client_tasks.push(tokio::spawn(async move {
+                let stream = raw_connect(&endpoint)
+                    .await
+                    .unwrap_or_else(|error| panic!("failed to connect streaming benchmark client: {error}"));
+                let mut reader = BufReader::new(stream);
+                let mut line = Vec::with_capacity(64);
+                let mut warmed = false;
+                loop {
+                    line.clear();
+                    let bytes = reader
+                        .read_until(b'\n', &mut line)
+                        .await
+                        .unwrap_or_else(|error| panic!("failed to read streaming benchmark message: {error}"));
+                    if bytes == 0 {
+                        break;
+                    }
+                    if line.as_slice() == b"warmup\n" && !warmed {
+                        warmed = true;
+                        let _ = event_tx.send(StreamEvent::Warmed).await;
+                    } else if line.as_slice() == b"payload\n" {
+                        let _ = event_tx.send(StreamEvent::ReceivedPayload).await;
+                    }
+                }
+            }));
+        }
+        drop(event_tx);
+
+        let mut context = Self {
+            sender: message_tx,
+            events: event_rx,
+            client_tasks,
+            server_task,
+        };
+        context.wait_until_clients_are_subscribed(clients).await;
+        context
+    }
+
+    async fn wait_until_clients_are_subscribed(&mut self, clients: usize) {
+        let deadline = Instant::now() + STARTUP_TIMEOUT;
+        let mut warmed = 0usize;
+        while warmed < clients {
+            self.sender
+                .send(StreamMessage::text(STREAM_WARMUP))
+                .await
+                .unwrap_or_else(|error| panic!("failed to publish stream warmup: {error}"));
+            while let Ok(event) = self.events.try_recv() {
+                if matches!(event, StreamEvent::Warmed) {
+                    warmed += 1;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "streaming benchmark clients did not subscribe in time"
+            );
+            tokio::task::yield_now().await;
+        }
+    }
+
+    async fn broadcast_once(&mut self, clients: usize) {
+        self.sender
+            .send(StreamMessage::text(STREAM_PAYLOAD))
+            .await
+            .unwrap_or_else(|error| panic!("failed to publish benchmark payload: {error}"));
+        let deadline = Instant::now() + REQUEST_TIMEOUT;
+        let mut received = 0usize;
+        while received < clients {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let event = timeout(remaining, self.events.recv())
+                .await
+                .unwrap_or_else(|_| panic!("streaming benchmark payload timed out"))
+                .unwrap_or_else(|| panic!("streaming benchmark event channel closed"));
+            if matches!(event, StreamEvent::ReceivedPayload) {
+                received += 1;
+            }
+        }
+    }
+}
+
+impl Drop for StreamBroadcastContext {
+    fn drop(&mut self) {
+        for task in &self.client_tasks {
+            task.abort();
+        }
+        self.server_task.abort();
+    }
+}
+
+fn bench_router_and_response(c: &mut Criterion, context: &HttpBenchContext) {
+    let mut group = c.benchmark_group("hot_path_router");
+    group.measurement_time(Duration::from_secs(6));
+    group.sample_size(40);
+    for (name, path) in [
+        ("literal", "/literal"),
+        ("param", "/items/42"),
+        ("query", "/query?page=42&sort=name"),
+    ] {
+        group.bench_function(name, |bencher| {
+            bencher.iter(|| {
+                assert!(context
+                    .router
+                    .find_handler_and_params(&Method::GET, path)
+                    .is_some());
+            });
+        });
+    }
+    group.finish();
+
+    let mut response_group = c.benchmark_group("hot_path_response_parse");
+    response_group.measurement_time(Duration::from_secs(6));
+    response_group.sample_size(40);
+    response_group.bench_function("client_response", |bencher| {
+        bencher.to_async(&context.runtime).iter(|| async {
+            let response = context
+                .client
+                .get("/response")
+                .send()
+                .await
+                .unwrap_or_else(|error| panic!("response benchmark failed: {error}"));
+            assert_eq!(response.json_value().expect("response must be JSON")["status"], "ok");
+        });
+    });
+    response_group.finish();
+}
+
+fn bench_metrics(c: &mut Criterion, context: &HttpBenchContext) {
+    let mut group = c.benchmark_group("hot_path_metrics");
+    group.measurement_time(Duration::from_secs(6));
+    group.sample_size(30);
+    for clients in [1usize, 32, 128] {
+        group.throughput(Throughput::Elements(clients as u64));
+        group.bench_with_input(
+            BenchmarkId::new("request_tracker", clients),
+            &clients,
+            |bencher, &clients| {
+                bencher.to_async(&context.runtime).iter_batched(
+                    || Arc::new(MetricsCollector::new()),
+                    |metrics| async move {
+                        let trackers = (0..clients).map(|_| {
+                            let metrics = Arc::clone(&metrics);
+                            async move { metrics.request_start("GET").success(200) }
+                        });
+                        join_all(trackers).await;
+                        assert_eq!(metrics.snapshot().successful_requests, clients as u64);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_pool_preheat(c: &mut Criterion, context: &HttpBenchContext) {
+    let mut group = c.benchmark_group("hot_path_pool_preheat");
+    group.measurement_time(Duration::from_secs(6));
+    group.sample_size(20);
+    for connections in [8usize, 32] {
+        group.throughput(Throughput::Elements(connections as u64));
+        group.bench_with_input(
+            BenchmarkId::new("connections", connections),
+            &connections,
+            |bencher, &connections| {
+                let endpoint = context.endpoint.clone();
+                bencher.to_async(&context.runtime).iter_batched(
+                    || build_client(&endpoint, true),
+                    |client| async move {
+                        client.preheat_for_puts(connections).await;
+                        let stats = client.pool_stats().expect("pooling is enabled");
+                        assert_eq!(stats.total_connections, connections);
+                        client.close();
+                    },
+                    BatchSize::LargeInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_fragmented_headers(c: &mut Criterion, context: &HttpBenchContext) {
+    let mut group = c.benchmark_group("hot_path_codec_fragmented_headers");
+    group.measurement_time(Duration::from_secs(6));
+    group.sample_size(30);
+    group.bench_function("two_fragments", |bencher| {
+        bencher
+            .to_async(&context.runtime)
+            .iter(|| fragmented_request(&context.endpoint));
+    });
+    group.finish();
+}
+
+fn bench_stream_broadcast(c: &mut Criterion, context: &HttpBenchContext) {
+    let mut group = c.benchmark_group("hot_path_stream_broadcast");
+    group.measurement_time(Duration::from_secs(6));
+    group.sample_size(20);
+    for clients in [1usize, 32, 64] {
+        group.throughput(Throughput::Elements(clients as u64));
+        group.bench_with_input(
+            BenchmarkId::new("broadcast_write_flush", clients),
+            &clients,
+            |bencher, &clients| {
+                let endpoint = unique_endpoint("stream");
+                let broadcast = Arc::new(Mutex::new(
+                    context
+                        .runtime
+                        .block_on(StreamBroadcastContext::start(endpoint, clients)),
+                ));
+                bencher.to_async(&context.runtime).iter(|| {
+                    let broadcast = Arc::clone(&broadcast);
+                    async move {
+                        broadcast.lock().await.broadcast_once(clients).await;
+                    }
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_retry_first_success(c: &mut Criterion, context: &HttpBenchContext) {
+    let mut group = c.benchmark_group("hot_path_retry");
+    group.measurement_time(Duration::from_secs(6));
+    group.sample_size(50);
+    group.bench_function("first_success_no_jitter", |bencher| {
+        bencher.to_async(&context.runtime).iter(|| async {
+            let executor = RetryExecutor::new(
+                RetryConfig::new()
+                    .max_attempts(3)
+                    .base_delay(Duration::from_secs(1))
+                    .jitter(JitterStrategy::None),
+            );
+            let result = executor
+                .execute(|| async { Ok::<_, KodeBridgeError>(()) })
+                .await
+                .unwrap_or_else(|error| panic!("first-success retry benchmark failed: {error}"));
+            assert_eq!(result, ());
+        });
+    });
+    group.finish();
+}
+
+fn benchmark_hot_path(c: &mut Criterion) {
+    let context = HttpBenchContext::new();
+    bench_router_and_response(c, &context);
+    bench_metrics(c, &context);
+    bench_pool_preheat(c, &context);
+    bench_fragmented_headers(c, &context);
+    bench_stream_broadcast(c, &context);
+    bench_retry_first_success(c, &context);
+}
+
+criterion_group!(benches, benchmark_hot_path);
+criterion_main!(benches);

--- a/benches/ipc_transport.rs
+++ b/benches/ipc_transport.rs
@@ -1,0 +1,267 @@
+#![allow(clippy::panic)]
+
+use bytes::Bytes;
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
+use futures::future::join_all;
+use kode_bridge::ipc_http_client::{ClientConfig, IpcHttpClient};
+use kode_bridge::ipc_http_server::{HttpResponse, IpcHttpServer, Router, ServerConfig};
+use kode_bridge::pool::PoolConfig;
+use serde_json::{json, Value};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+use tokio::runtime::Runtime;
+use tokio::task::JoinHandle;
+use tokio::time::{timeout, Instant};
+
+const SMALL_PAYLOAD_SIZE: usize = 256;
+const LARGE_PAYLOAD_SIZE: usize = 512 * 1024;
+const BURST_SIZE: usize = 32;
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
+
+static ENDPOINT_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+struct BenchContext {
+    runtime: Runtime,
+    endpoint: PathBuf,
+    server_task: Option<JoinHandle<kode_bridge::Result<()>>>,
+    direct_client: IpcHttpClient,
+    pooled_client: IpcHttpClient,
+    small_payload: Value,
+    large_payload: Value,
+}
+
+impl BenchContext {
+    fn new() -> Self {
+        let runtime = match Runtime::new() {
+            Ok(runtime) => runtime,
+            Err(error) => panic!("failed to create benchmark runtime: {error}"),
+        };
+        let endpoint = unique_endpoint();
+        let router = Router::new()
+            .get("/ready", |_ctx| async { Ok(HttpResponse::text("ready")) })
+            .get("/small", |_ctx| async {
+                Ok(HttpResponse::builder()
+                    .header("content-type", "application/json")
+                    .body(Bytes::from_static(b"{\"ok\":true}"))
+                    .build())
+            })
+            .post("/echo", |ctx| async move {
+                Ok(HttpResponse::builder()
+                    .header("content-type", "application/json")
+                    .body(ctx.body)
+                    .build())
+            });
+        let mut server = match IpcHttpServer::with_config(
+            &endpoint,
+            ServerConfig {
+                max_connections: BURST_SIZE + 16,
+                read_timeout: Duration::from_secs(5),
+                write_timeout: Duration::from_secs(5),
+                max_request_size: 2 * 1024 * 1024,
+                max_header_size: 16 * 1024,
+                enable_logging: false,
+                max_requests_per_connection: 100_000,
+                shutdown_timeout: Duration::from_secs(1),
+            },
+        ) {
+            Ok(server) => server.router(router),
+            Err(error) => panic!("failed to configure benchmark server: {error}"),
+        };
+        let server_task = runtime.spawn(async move { server.serve().await });
+
+        let direct_client = build_client(&endpoint, false);
+        runtime.block_on(wait_until_ready(&endpoint, &server_task));
+        let pooled_client = build_client(&endpoint, true);
+        runtime.block_on(pooled_client.preheat_for_puts(BURST_SIZE));
+
+        Self {
+            runtime,
+            endpoint,
+            server_task: Some(server_task),
+            direct_client,
+            pooled_client,
+            small_payload: payload(SMALL_PAYLOAD_SIZE),
+            large_payload: payload(LARGE_PAYLOAD_SIZE),
+        }
+    }
+}
+
+impl Drop for BenchContext {
+    fn drop(&mut self) {
+        self.direct_client.close();
+        self.pooled_client.close();
+        if let Some(task) = self.server_task.take() {
+            task.abort();
+            let result = self.runtime.block_on(task);
+            assert!(result.is_err_and(|error| error.is_cancelled()));
+        }
+    }
+}
+
+fn unique_endpoint() -> PathBuf {
+    let sequence = ENDPOINT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+
+    #[cfg(unix)]
+    {
+        PathBuf::from(format!("/tmp/kb-bench-{}-{sequence}.sock", std::process::id()))
+    }
+
+    #[cfg(windows)]
+    {
+        PathBuf::from(format!(r"\\.\pipe\kb-bench-{}-{sequence}", std::process::id()))
+    }
+}
+
+const fn client_config(enable_pooling: bool) -> ClientConfig {
+    ClientConfig {
+        default_timeout: Duration::from_secs(5),
+        pool_config: PoolConfig {
+            max_size: BURST_SIZE + 16,
+            min_idle: 0,
+            max_idle_time_ms: 120_000,
+            connection_timeout_ms: 3_000,
+            retry_delay_ms: 5,
+            max_retries: 3,
+            max_concurrent_requests: BURST_SIZE + 16,
+            max_requests_per_second: None,
+        },
+        enable_pooling,
+        max_retries: 3,
+        retry_delay: Duration::from_millis(5),
+        max_concurrent_requests: BURST_SIZE + 16,
+        max_requests_per_second: None,
+    }
+}
+
+fn build_client(path: &Path, enable_pooling: bool) -> IpcHttpClient {
+    match IpcHttpClient::with_config(path, client_config(enable_pooling)) {
+        Ok(client) => client,
+        Err(error) => panic!("failed to build benchmark client: {error}"),
+    }
+}
+
+async fn wait_until_ready(endpoint: &Path, server_task: &JoinHandle<kode_bridge::Result<()>>) {
+    let deadline = Instant::now() + STARTUP_TIMEOUT;
+    loop {
+        assert!(!server_task.is_finished(), "benchmark server exited before readiness");
+        let client = build_client(endpoint, false);
+        if let Ok(Ok(response)) = timeout(Duration::from_millis(250), client.get("/ready").send()).await {
+            if response.is_success() {
+                return;
+            }
+        }
+        assert!(Instant::now() < deadline, "benchmark server readiness timed out");
+        tokio::task::yield_now().await;
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
+
+fn payload(size: usize) -> Value {
+    json!({"payload": "x".repeat(size)})
+}
+
+fn bench_connection_costs(c: &mut Criterion, context: &BenchContext) {
+    let mut group = c.benchmark_group("ipc_transport_connection");
+    group.measurement_time(Duration::from_secs(8));
+    group.sample_size(40);
+
+    group.bench_function("cold_client_get", |bencher| {
+        let endpoint = context.endpoint.clone();
+        bencher.to_async(&context.runtime).iter_batched(
+            || build_client(&endpoint, false),
+            |client| async move {
+                let response = match client.get("/small").send().await {
+                    Ok(response) => response,
+                    Err(error) => panic!("cold benchmark request failed: {error}"),
+                };
+                assert!(response.is_success());
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("direct_get", |bencher| {
+        bencher.to_async(&context.runtime).iter(|| async {
+            let response = match context.direct_client.get("/small").send().await {
+                Ok(response) => response,
+                Err(error) => panic!("direct benchmark request failed: {error}"),
+            };
+            assert!(response.is_success());
+        });
+    });
+
+    group.bench_function("warm_pooled_get", |bencher| {
+        bencher.to_async(&context.runtime).iter(|| async {
+            let response = match context.pooled_client.get("/small").send().await {
+                Ok(response) => response,
+                Err(error) => panic!("pooled benchmark request failed: {error}"),
+            };
+            assert!(response.is_success());
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_payload_round_trip(c: &mut Criterion, context: &BenchContext) {
+    let mut group = c.benchmark_group("ipc_transport_payload");
+    group.measurement_time(Duration::from_secs(8));
+    group.sample_size(30);
+
+    for (name, value, size) in [
+        ("small", &context.small_payload, SMALL_PAYLOAD_SIZE),
+        ("large", &context.large_payload, LARGE_PAYLOAD_SIZE),
+    ] {
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(BenchmarkId::new("pooled_echo", name), value, |bencher, payload| {
+            bencher.to_async(&context.runtime).iter(|| async {
+                let response = match context
+                    .pooled_client
+                    .post("/echo")
+                    .json_body(payload)
+                    .timeout(Duration::from_secs(10))
+                    .send()
+                    .await
+                {
+                    Ok(response) => response,
+                    Err(error) => panic!("payload benchmark request failed: {error}"),
+                };
+                assert!(response.is_success());
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_concurrent_burst(c: &mut Criterion, context: &BenchContext) {
+    let mut group = c.benchmark_group("ipc_transport_concurrency");
+    group.measurement_time(Duration::from_secs(8));
+    group.sample_size(30);
+    group.throughput(Throughput::Elements(BURST_SIZE as u64));
+
+    group.bench_function(BenchmarkId::new("pooled_get_burst", BURST_SIZE), |bencher| {
+        bencher.to_async(&context.runtime).iter(|| async {
+            let requests = (0..BURST_SIZE).map(|_| context.pooled_client.get("/small").send());
+            for result in join_all(requests).await {
+                match result {
+                    Ok(response) => assert!(response.is_success()),
+                    Err(error) => panic!("concurrent benchmark request failed: {error}"),
+                }
+            }
+        });
+    });
+
+    group.finish();
+}
+
+fn benchmark_ipc_transport(c: &mut Criterion) {
+    let context = BenchContext::new();
+    bench_connection_costs(c, &context);
+    bench_payload_round_trip(c, &context);
+    bench_concurrent_burst(c, &context);
+}
+
+criterion_group!(benches, benchmark_ipc_transport);
+criterion_main!(benches);

--- a/benches/ipc_transport.rs
+++ b/benches/ipc_transport.rs
@@ -61,7 +61,7 @@ impl BenchContext {
                 max_request_size: 2 * 1024 * 1024,
                 max_header_size: 16 * 1024,
                 enable_logging: false,
-                max_requests_per_connection: 100_000,
+                max_requests_per_connection: usize::MAX,
                 shutdown_timeout: Duration::from_secs(1),
             },
         ) {

--- a/benches/ipc_transport.rs
+++ b/benches/ipc_transport.rs
@@ -73,7 +73,6 @@ impl BenchContext {
         let direct_client = build_client(&endpoint, false);
         runtime.block_on(wait_until_ready(&endpoint, &server_task));
         let pooled_client = build_client(&endpoint, true);
-        runtime.block_on(pooled_client.preheat_for_puts(BURST_SIZE));
 
         Self {
             runtime,
@@ -190,6 +189,10 @@ fn bench_connection_costs(c: &mut Criterion, context: &BenchContext) {
             assert!(response.is_success());
         });
     });
+
+    context
+        .runtime
+        .block_on(context.pooled_client.preheat_for_puts(BURST_SIZE));
 
     group.bench_function("warm_pooled_get", |bencher| {
         bencher.to_async(&context.runtime).iter(|| async {

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -1,27 +1,36 @@
-# Migration and Modernization Guide
+# Migrating from 0.4 to 0.5
 
-Complete guide for migrating to kode-bridge's modern architecture.
+kode-bridge 0.5 replaces `interprocess` with a small transport layer backed by
+Tokio Unix domain sockets and Windows named pipes. The HTTP-over-IPC wire
+format, normal client and server constructors, request builders, routing, pool
+behavior, and streaming formats are unchanged.
 
-## Migrating from 0.4 to 0.5
+## Requirements
 
-Version 0.5 replaces the `interprocess` dependency with kode-bridge's Tokio-native transport adapter. The HTTP-over-IPC wire format and the normal client/server constructors, request methods, and permission builders are unchanged. Most applications only need to update the dependency version.
+Update the dependency and toolchain together:
 
 ```toml
 [dependencies]
 kode-bridge = "0.5"
 ```
 
-The minimum supported Rust version is now 1.87. This matches the toolchain used by kode-bridge CI and the minimum required by its current target dependencies.
+- The minimum supported Rust version is 1.87.
+- The default feature remains `client`.
+- Use `features = ["server"]` for server-only applications and
+  `features = ["full"]` when both sides are needed.
 
-Three public type boundaries necessarily change because 0.4 exposed types owned by `interprocess`:
+## Necessary API changes
+
+Version 0.4 exposed three types owned by `interprocess`. Version 0.5 replaces
+only those boundaries with kode-bridge-owned types.
 
 | 0.4 API | 0.5 API | Migration |
-|---------|---------|-----------|
-| Server `with_listener_options(interprocess::...::ListenerOptions)` | `with_listener_options(kode_bridge::ListenerOptions)` | Import and build `kode_bridge::ListenerOptions`. |
+| --- | --- | --- |
+| `with_listener_options(interprocess::...::ListenerOptions)` | `with_listener_options(kode_bridge::ListenerOptions)` | Import and construct `kode_bridge::ListenerOptions`. |
 | `ConnectionPool::{new, with_default_config}(Name)` | The same methods accepting `kode_bridge::Endpoint` | Validate the path once with `Endpoint::new(path)?`. |
-| `PooledConnection::{stream, into_stream}` returning `LocalSocketStream` | The same methods returning `kode_bridge::IpcStream` | Remove explicit `LocalSocketStream` annotations; `IpcStream` implements Tokio `AsyncRead` and `AsyncWrite`. |
+| `PooledConnection::{stream, into_stream}` returning `LocalSocketStream` | The same methods returning `kode_bridge::IpcStream` | Remove explicit `LocalSocketStream` annotations. `IpcStream` implements Tokio `AsyncRead` and `AsyncWrite`, including vectored writes. |
 
-For example, direct pool construction now uses an `Endpoint`:
+Direct pool construction now uses an `Endpoint`:
 
 ```rust
 use kode_bridge::{
@@ -33,7 +42,31 @@ let endpoint = Endpoint::new("/tmp/service.sock")?;
 let pool = ConnectionPool::new(endpoint, PoolConfig::default());
 ```
 
-Server permission builders keep their prior call shape:
+Most applications only use `IpcHttpClient::new`, `IpcStreamClient::new`,
+`IpcHttpServer::new`, or `IpcStreamServer::new`; those constructors still
+accept a path and do not require an explicit `Endpoint`.
+
+## Endpoint rules
+
+Use a platform-appropriate endpoint:
+
+```rust
+#[cfg(unix)]
+let endpoint = "/tmp/service.sock";
+
+#[cfg(windows)]
+let endpoint = r"\\.\pipe\service";
+```
+
+- Unix endpoints are file-system paths and cannot contain an interior NUL.
+- Windows endpoints must use `\\HOST\pipe\NAME`; normal local endpoints use
+  `\\.\pipe\NAME`.
+- Endpoint validation now happens when the client, server, or `Endpoint` is
+  constructed.
+
+## Listener configuration
+
+The convenience builders retain their 0.4 call shape:
 
 ```rust
 #[cfg(all(unix, not(target_os = "macos")))]
@@ -45,231 +78,64 @@ let server = IpcHttpServer::new(r"\\.\pipe\service")?
     .with_listener_security_descriptor("D:(A;;GA;;;WD)");
 ```
 
-Unix listeners still clean up their socket path when dropped. They do not replace stale paths by default. Cleanup checks the path's socket type and device/inode identity, but safe standard-library APIs cannot make compare-and-delete atomic; use a trusted parent directory that untrusted processes cannot modify. Windows endpoint strings must use `\\HOST\pipe\NAME`; malformed paths and invalid SDDL are rejected during configuration.
+For advanced Unix listener behavior:
 
-## 🔄 Migration from Platform-Specific Code
-
-### Migration from Platform-Specific Code
-
-If you were previously using platform-specific imports:
-
-#### Before (Legacy):
 ```rust
 #[cfg(unix)]
-use kode_bridge::ipc_cilent::unix::UnixIpcHttpClient as IpcHttpClient;
-#[cfg(windows)] 
-use kode_bridge::ipc_cilent::windows::WindowsIpcHttpClient as IpcHttpClient;
-
-// Legacy API usage
-let client = IpcHttpClient::new("/tmp/service.sock")?;
-let response = client.request("GET", "/api/status", None).await?;
+let options = kode_bridge::ListenerOptions::new()
+    .reclaim_name(true)
+    .try_overwrite(true)
+    .max_spin_time(std::time::Duration::from_millis(100));
 ```
 
-#### Now (Modern):
-```rust
-use kode_bridge::{IpcHttpClient, ClientConfig};
-use std::time::Duration;
+Important behavior:
 
-// Modern unified import with advanced configuration
-let config = ClientConfig {
-    enable_pooling: true,
-    max_retries: 3,
-    ..Default::default()
-};
+- `reclaim_name(true)` remains the default and removes the listener's own Unix
+  socket path on drop.
+- Stale Unix sockets are not replaced unless `try_overwrite(true)` is set.
+- Overwrite refuses regular files and listeners that still accept connections.
+- Unix compare-and-delete cannot be made atomic with the safe standard-library
+  APIs used here. Put production sockets in a trusted parent directory.
+- Custom Unix mode is applied before listening on supported Unix platforms.
+  It currently returns `Unsupported` on macOS.
+- Windows named pipes reject remote clients. A configured SDDL descriptor is
+  applied to every pipe instance.
+- Invalid Windows SDDL retains the 0.4 builder behavior and panics during
+  configuration. Validate untrusted SDDL before passing it to the builder.
 
-let client = IpcHttpClient::with_config("/tmp/service.sock", config)?;
+## Behavior preserved by the new transport
 
-// Modern fluent API
-let response = client
-    .get("/api/status")
-    .timeout(Duration::from_secs(10))
-    .send()
-    .await?;
+- HTTP request and response bytes, headers, methods, and JSON handling
+- Client request timeouts and retry boundaries
+- Pool reuse, invalidation, preheating, and per-connection request limits
+- Unix listener cleanup and explicit stale-path policy
+- Windows pipe-busy retry, 512-byte pipe buffers, and flush-on-drop delivery
+- HTTP-style streaming client parsing and newline-delimited stream-server frames
 
-// Legacy API still supported for backward compatibility
-let response = client.request("GET", "/api/status", None).await?;
-```
+`IpcStreamClient` and `IpcStreamServer` are not a matched pair in 0.5:
+`IpcStreamClient` consumes an HTTP-style streaming response, while
+`IpcStreamServer` broadcasts raw newline-delimited messages. This is existing
+behavior, not a transport migration change.
 
-### Modernization Benefits
+## Verification checklist
 
-#### Code Simplification
-- **Single Import**: No more platform-specific conditional imports
-- **Unified API**: Same interface across all platforms
-- **Modern Syntax**: Fluent API similar to reqwest
+After updating:
 
-#### New Features
-- **Connection Pooling**: Automatic connection management
-- **Type-Safe JSON**: Automatic serialization/deserialization
-- **Rich Error Handling**: Categorized errors with context
-- **Streaming Support**: Real-time data processing
-- **Configuration System**: Flexible environment-based setup
-
-### Migration Checklist
-
-#### Step 1: Update Dependencies
-```toml
-[dependencies]
-kode-bridge = "0.5"
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-```
-
-#### Step 2: Update Imports
-```rust
-// Remove platform-specific imports
-// #[cfg(unix)] use kode_bridge::ipc_cilent::unix::...
-
-// Add modern unified imports
-use kode_bridge::{IpcHttpClient, IpcStreamClient, ClientConfig, StreamClientConfig};
-```
-
-#### Step 3: Modernize Client Creation
-```rust
-// Old way
-let client = IpcHttpClient::new(path)?;
-
-// New way with configuration
-let client = IpcHttpClient::with_config(path, ClientConfig::default())?;
-```
-
-#### Step 4: Update Request Patterns
-```rust
-// Legacy (still works)
-let response = client.request("GET", "/api/data", None).await?;
-
-// Modern fluent API (recommended)
-let response = client
-    .get("/api/data")
-    .timeout(Duration::from_secs(5))
-    .send()
-    .await?;
-```
-
-#### Step 5: Add Error Handling
-```rust
-// Enhanced error handling
-if response.is_success() {
-    let data: MyType = response.json()?;
-    println!("Success: {:?}", data);
-} else if response.is_client_error() {
-    println!("Client error: {}", response.status());
-} else if response.is_server_error() {
-    println!("Server error: {}", response.status());
-}
-```
-
-## 🎯 Best Practices by Platform
-
-### Unix/Linux/macOS Best Practices
-
-#### Development
 ```bash
-# Use /tmp for development
-CUSTOM_SOCK=/tmp/dev_myapp.sock
-
-# Ensure cleanup
-trap "rm -f /tmp/dev_myapp.sock" EXIT
+cargo check --all-features
+cargo test --all-features
+cargo doc --all-features --no-deps
 ```
 
-#### Production
+Applications that directly used one of the three replaced public types should
+also compile their own public API or downstream fixture.
+
+To compare performance on the same host and toolchain:
+
 ```bash
-# Use /var/run for production
-CUSTOM_SOCK=/var/run/myapp/api.sock
-
-# Set proper permissions
-sudo mkdir -p /var/run/myapp
-sudo chown myapp:myapp /var/run/myapp
+cargo bench --all-features --bench bench_version
+cargo bench --all-features --bench ipc_transport
 ```
 
-### Windows Best Practices
-
-#### Development
-```cmd
-REM Use descriptive pipe names
-set CUSTOM_PIPE=\\\\.\\pipe\\myapp_dev
-```
-
-#### Production
-```cmd
-REM Use service-specific names
-set CUSTOM_PIPE=\\\\.\\pipe\\myapp_production
-
-REM For Windows services
-net start MyAppService
-```
-
-#### PowerShell
-```powershell
-# Environment setup
-$env:CUSTOM_PIPE="\\\\.\\pipe\\myapp"
-
-# Service management
-Start-Service -Name "MyAppService"
-```
-
-## 🚀 Performance Optimization Tips
-
-### Connection Pooling
-```rust
-// Optimize pool settings based on usage
-let config = ClientConfig {
-    enable_pooling: true,
-    pool_max_size: 20,      // Adjust based on concurrent load
-    pool_min_idle: 5,       // Keep minimum connections ready
-    pool_max_idle_time_ms: 30000, // 30 seconds
-    ..Default::default()
-};
-```
-
-### Buffer Optimization
-```rust
-// For high-throughput streaming
-let stream_config = StreamClientConfig {
-    buffer_size: 65536, // 64KB for high-volume data
-    ..Default::default()
-};
-
-// For low-latency scenarios
-let stream_config = StreamClientConfig {
-    buffer_size: 4096,  // 4KB for low latency
-    ..Default::default()
-};
-```
-
-### Timeout Configuration
-```rust
-// Different timeout strategies
-let config = ClientConfig {
-    default_timeout: Duration::from_secs(30), // Global timeout
-    ..Default::default()
-};
-
-// Per-request timeout
-let response = client
-    .get("/api/data")
-    .timeout(Duration::from_secs(5)) // Override global timeout
-    .send()
-    .await?;
-```
-
-## 📈 Performance Comparison
-
-### Before vs After Migration
-
-| Feature | Legacy | Modern | Improvement |
-|---------|--------|--------|-------------|
-| Code Lines | 50+ lines | 10-15 lines | 70% reduction |
-| Error Handling | Basic | Rich categorized | Better debugging |
-| Connection Management | Manual | Automatic pooling | 3x throughput |
-| Platform Support | Conditional | Unified | Simplified code |
-| API Style | Verbose | Fluent/Chainable | Better readability |
-| Type Safety | Limited | Full JSON support | Fewer runtime errors |
-
-### Migration Timeline
-
-1. **Phase 1 (Week 1)**: Update dependencies and imports
-2. **Phase 2 (Week 2)**: Modernize core request patterns
-3. **Phase 3 (Week 3)**: Add advanced features (pooling, streaming)
-4. **Phase 4 (Week 4)**: Performance optimization and testing
-5. **Phase 5 (Week 5)**: Production deployment and monitoring
+Do not compare Criterion results from different hosts or shared CI runners as
+if they were a controlled before/after measurement.

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -2,6 +2,51 @@
 
 Complete guide for migrating to kode-bridge's modern architecture.
 
+## Migrating from 0.4 to 0.5
+
+Version 0.5 replaces the `interprocess` dependency with kode-bridge's Tokio-native transport adapter. The HTTP-over-IPC wire format and the normal client/server constructors, request methods, and permission builders are unchanged. Most applications only need to update the dependency version.
+
+```toml
+[dependencies]
+kode-bridge = "0.5"
+```
+
+The minimum supported Rust version is now 1.87. This matches the toolchain used by kode-bridge CI and the minimum required by its current target dependencies.
+
+Three public type boundaries necessarily change because 0.4 exposed types owned by `interprocess`:
+
+| 0.4 API | 0.5 API | Migration |
+|---------|---------|-----------|
+| Server `with_listener_options(interprocess::...::ListenerOptions)` | `with_listener_options(kode_bridge::ListenerOptions)` | Import and build `kode_bridge::ListenerOptions`. |
+| `ConnectionPool::{new, with_default_config}(Name)` | The same methods accepting `kode_bridge::Endpoint` | Validate the path once with `Endpoint::new(path)?`. |
+| `PooledConnection::{stream, into_stream}` returning `LocalSocketStream` | The same methods returning `kode_bridge::IpcStream` | Remove explicit `LocalSocketStream` annotations; `IpcStream` implements Tokio `AsyncRead` and `AsyncWrite`. |
+
+For example, direct pool construction now uses an `Endpoint`:
+
+```rust
+use kode_bridge::{
+    pool::{ConnectionPool, PoolConfig},
+    Endpoint,
+};
+
+let endpoint = Endpoint::new("/tmp/service.sock")?;
+let pool = ConnectionPool::new(endpoint, PoolConfig::default());
+```
+
+Server permission builders keep their prior call shape:
+
+```rust
+#[cfg(all(unix, not(target_os = "macos")))]
+let server = IpcHttpServer::new("/tmp/service.sock")?
+    .with_listener_mode(0o640);
+
+#[cfg(windows)]
+let server = IpcHttpServer::new(r"\\.\pipe\service")?
+    .with_listener_security_descriptor("D:(A;;GA;;;WD)");
+```
+
+Unix listeners still clean up their socket path when dropped. They do not replace stale paths by default. Cleanup checks the path's socket type and device/inode identity, but safe standard-library APIs cannot make compare-and-delete atomic; use a trusted parent directory that untrusted processes cannot modify. Windows endpoint strings must use `\\HOST\pipe\NAME`; malformed paths and invalid SDDL are rejected during configuration.
+
 ## 🔄 Migration from Platform-Specific Code
 
 ### Migration from Platform-Specific Code
@@ -64,7 +109,7 @@ let response = client.request("GET", "/api/status", None).await?;
 #### Step 1: Update Dependencies
 ```toml
 [dependencies]
-kode-bridge = "0.1"
+kode-bridge = "0.5"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/docs/platform-configuration.md
+++ b/docs/platform-configuration.md
@@ -168,8 +168,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 #### Configuration
 - **Default Path**: `/tmp/example.sock`
-- **Permissions**: Automatically handles socket file permissions
-- **Cleanup**: Automatic socket file cleanup on client shutdown
+- **Permissions**: Use `.with_listener_mode(mode)` on supported Unix systems; custom mode is currently unsupported on macOS
+- **Cleanup**: The listener removes its own socket file on drop, but does not replace a stale socket by default
+
+For advanced listener configuration, use kode-bridge's own `ListenerOptions`:
+
+```rust
+use kode_bridge::{IpcHttpServer, ListenerOptions};
+use std::time::Duration;
+
+let options = ListenerOptions::new()
+    .reclaim_name(true)
+    .try_overwrite(true)
+    .max_spin_time(Duration::from_millis(100));
+let server = IpcHttpServer::new("/tmp/example.sock")?
+    .with_listener_options(options);
+```
+
+`try_overwrite(true)` only attempts to replace a path verified as the same stale Unix socket. It refuses regular files and live listeners. Startup and cleanup re-check the socket type and device/inode identity before acting.
+
+These checks are not an atomic compare-and-delete operation: safe standard-library APIs leave a residual race if another process can replace the path after the final metadata check. Put production sockets in a trusted parent directory that untrusted users cannot modify.
 
 #### Best Practices
 ```bash
@@ -196,7 +214,14 @@ CUSTOM_SOCK=/var/run/my_app/api.sock
 #### Configuration
 - **Default Path**: `\\.\\pipe\\example`
 - **Namespace**: Uses the `\\.\\pipe\\` namespace
-- **Security**: Automatic security descriptor management
+- **Security**: Named pipes reject remote clients by default; custom SDDL is applied to every instance
+
+```rust
+let server = IpcHttpServer::new(r"\\.\pipe\example")?
+    .with_listener_security_descriptor("D:(A;;GA;;;WD)");
+```
+
+Invalid SDDL is rejected immediately by the builder. The default client retains Tokio's identification-level security quality-of-service settings.
 
 #### Best Practices
 ```cmd

--- a/docs/platform-configuration.md
+++ b/docs/platform-configuration.md
@@ -1,258 +1,194 @@
 # Platform Configuration Guide
 
-Complete guide for configuring kode-bridge across different platforms.
+kode-bridge constructors take an endpoint path directly. Environment variables
+are an application concern; the checked-in examples use `CUSTOM_SOCK` on Unix
+and `CUSTOM_PIPE` on Windows, but the library does not read either variable.
 
-## 🌍 Cross-Platform Configuration
+## Endpoint configuration
 
-### Environment Variables
+### Unix
 
-The library automatically detects your platform and uses appropriate IPC transport:
-
-#### Unix/Linux/macOS (Unix Domain Sockets)
-- **Variable**: `CUSTOM_SOCK`
-- **Default**: `/tmp/example.sock`
-- **Format**: Absolute path to socket file
-- **Examples**: 
-  ```bash
-  # Basic usage
-  CUSTOM_SOCK=/tmp/my_service.sock cargo run --example request
-  
-  # Service-specific paths
-  CUSTOM_SOCK=/var/run/my_app/api.sock cargo run --example elegant_http
-  CUSTOM_SOCK=/tmp/clash_api.sock cargo run --example traffic
-  ```
-
-#### Windows (Named Pipes)
-- **Variable**: `CUSTOM_PIPE` 
-- **Default**: `\\.\\pipe\\example`
-- **Format**: `\\.\\pipe\\pipe_name`
-- **Examples**:
-  ```cmd
-  REM Basic usage
-  set CUSTOM_PIPE=\\.\\pipe\\my_service
-  cargo run --example request
-  
-  REM Service-specific pipes
-  set CUSTOM_PIPE=\\.\\pipe\\clash_api
-  cargo run --example traffic
-  
-  REM PowerShell
-  $env:CUSTOM_PIPE="\\.\\pipe\\my_service"
-  cargo run --example elegant_http
-  ```
-
-### Modern Configuration Options
-
-#### HTTP Client Configuration
-```rust
-use kode_bridge::{IpcHttpClient, ClientConfig};
-use std::time::Duration;
-
-let config = ClientConfig {
-    default_timeout: Duration::from_secs(30),
-    enable_pooling: true,
-    pool_max_size: 10,
-    pool_min_idle: 2,
-    pool_max_idle_time_ms: 30000,
-    max_retries: 3,
-    retry_delay: Duration::from_millis(200),
-};
-
-let client = IpcHttpClient::with_config(&ipc_path, config)?;
+```bash
+CUSTOM_SOCK=/tmp/my-service.sock cargo run --example request
 ```
 
-#### Streaming Client Configuration
+Use `/tmp` for local development. For a production service, prefer a dedicated
+directory such as `/run/my-app` whose ownership and permissions prevent
+untrusted path replacement.
+
+```bash
+sudo install -d -o myapp -g myapp -m 0750 /run/my-app
+CUSTOM_SOCK=/run/my-app/api.sock cargo run --example request
+```
+
+Unix endpoints may be relative or absolute file-system paths, but cannot
+contain an interior NUL. The parent directory must already exist.
+
+### Windows
+
+Command Prompt:
+
+```cmd
+set CUSTOM_PIPE=\\.\pipe\my-service
+cargo run --example request
+```
+
+PowerShell:
+
+```powershell
+$env:CUSTOM_PIPE='\\.\pipe\my-service'
+cargo run --example request
+```
+
+Windows endpoints must use `\\HOST\pipe\NAME`. kode-bridge servers reject
+remote clients, so use the local `\\.\pipe\NAME` form.
+
+### `.env` examples
+
+Unquoted `.env` values do not need Rust string-literal escaping:
+
+```env
+# Unix
+CUSTOM_SOCK=/tmp/my-service.sock
+
+# Windows
+CUSTOM_PIPE=\\.\pipe\my-service
+```
+
+The examples call `dotenvy::dotenv()` before reading these values. Add
+`dotenvy` to your own application if you want the same behavior.
+
+## HTTP client configuration
+
+`ClientConfig` contains a nested `PoolConfig`; the older flattened
+`pool_max_size` and `pool_min_idle` fields do not exist.
+
+```rust
+use kode_bridge::{pool::PoolConfig, ClientConfig, IpcHttpClient};
+use std::time::Duration;
+
+let pool = PoolConfig {
+    max_size: 16,
+    min_idle: 4,
+    max_idle_time_ms: 30_000,
+    connection_timeout_ms: 5_000,
+    retry_delay_ms: 25,
+    max_retries: 3,
+    max_concurrent_requests: 16,
+    max_requests_per_second: None,
+};
+
+let config = ClientConfig {
+    default_timeout: Duration::from_secs(5),
+    pool_config: pool,
+    enable_pooling: true,
+    max_retries: 3,
+    retry_delay: Duration::from_millis(25),
+    max_concurrent_requests: 16,
+    max_requests_per_second: Some(50.0),
+};
+
+let client = IpcHttpClient::with_config(endpoint, config)?;
+```
+
+Choose pool limits from measured concurrent demand. A larger pool consumes more
+open handles and memory and does not guarantee lower latency.
+
+## Streaming client configuration
+
 ```rust
 use kode_bridge::{IpcStreamClient, StreamClientConfig};
 use std::time::Duration;
 
 let config = StreamClientConfig {
     default_timeout: Duration::from_secs(60),
-    max_retries: 5,
+    max_retries: 3,
     retry_delay: Duration::from_millis(100),
-    buffer_size: 32768, // Large buffer for high-throughput
+    buffer_size: 16 * 1024,
 };
 
-let stream_client = IpcStreamClient::with_config(&ipc_path, config)?;
+let client = IpcStreamClient::with_config(endpoint, config)?;
 ```
 
-## 📄 Environment File Configuration
+The buffer size is a user-space read buffer, not the Windows named-pipe kernel
+buffer size. Measure memory and throughput before increasing it broadly.
 
-### .env File Support
-
-Create a `.env` file in your project root for persistent configuration:
-
-#### Unix/Linux/macOS .env example:
-```env
-# Unix Domain Socket configuration
-CUSTOM_SOCK=/tmp/my_service.sock
-
-# Alternative paths
-# CUSTOM_SOCK=/var/run/my_app/api.sock
-# CUSTOM_SOCK=/tmp/clash_api.sock
-```
-
-#### Windows .env example:
-```env
-# Named Pipe configuration (note: each backslash doubled for escaping)
-CUSTOM_PIPE=\\\\.\\pipe\\my_service
-
-# Alternative pipes
-# CUSTOM_PIPE=\\\\.\\pipe\\clash_api
-# CUSTOM_PIPE=\\\\.\\pipe\\app_communication
-```
-
-### Advanced Environment Configuration
-
-#### Development vs Production
-```env
-# Development
-CUSTOM_SOCK=/tmp/dev_service.sock
-LOG_LEVEL=debug
-ENABLE_POOLING=true
-MAX_RETRIES=3
-
-# Production (different .env file)
-CUSTOM_SOCK=/var/run/production/api.sock
-LOG_LEVEL=info
-ENABLE_POOLING=true
-MAX_RETRIES=5
-POOL_SIZE=20
-```
-
-#### Using Environment in Code
-```rust
-use dotenv::dotenv;
-use std::env;
-use kode_bridge::{ClientConfig, IpcHttpClient};
-
-#[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    dotenv().ok();
-    
-    // Platform-specific path resolution
-    #[cfg(unix)]
-    let ipc_path = env::var("CUSTOM_SOCK")
-        .unwrap_or_else(|_| "/tmp/default.sock".to_string());
-    
-    #[cfg(windows)]
-    let ipc_path = env::var("CUSTOM_PIPE")
-        .unwrap_or_else(|_| r"\\.\\pipe\\default".to_string());
-    
-    // Environment-driven configuration
-    let enable_pooling = env::var("ENABLE_POOLING")
-        .unwrap_or_else(|_| "true".to_string())
-        .parse::<bool>()
-        .unwrap_or(true);
-    
-    let config = ClientConfig {
-        enable_pooling,
-        ..Default::default()
-    };
-    
-    let client = IpcHttpClient::with_config(&ipc_path, config)?;
-    
-    Ok(())
-}
-```
-
-## 🔧 Platform-Specific Features and Optimizations
-
-### Unix/Linux/macOS (Unix Domain Sockets)
-
-#### Advantages
-- **Superior Performance**: Direct kernel communication without network stack
-- **Connection Pooling**: Excellent connection reuse and pooling performance
-- **File System Integration**: Socket files integrate with standard file permissions
-- **Process Communication**: Ideal for local service communication
-
-#### Configuration
-- **Default Path**: `/tmp/example.sock`
-- **Permissions**: Use `.with_listener_mode(mode)` on supported Unix systems; custom mode is currently unsupported on macOS
-- **Cleanup**: The listener removes its own socket file on drop, but does not replace a stale socket by default
-
-For advanced listener configuration, use kode-bridge's own `ListenerOptions`:
+## HTTP server configuration
 
 ```rust
-use kode_bridge::{IpcHttpServer, ListenerOptions};
+use kode_bridge::ServerConfig;
 use std::time::Duration;
 
-let options = ListenerOptions::new()
-    .reclaim_name(true)
-    .try_overwrite(true)
-    .max_spin_time(Duration::from_millis(100));
-let server = IpcHttpServer::new("/tmp/example.sock")?
-    .with_listener_options(options);
+let config = ServerConfig {
+    max_connections: 128,
+    read_timeout: Duration::from_secs(5),
+    write_timeout: Duration::from_secs(5),
+    max_request_size: 10 * 1024 * 1024,
+    max_header_size: 4096,
+    enable_logging: true,
+    max_requests_per_connection: 32,
+    shutdown_timeout: Duration::from_secs(3),
+};
 ```
 
-`try_overwrite(true)` only attempts to replace a path verified as the same stale Unix socket. It refuses regular files and live listeners. Startup and cleanup re-check the socket type and device/inode identity before acting.
+`read_timeout` bounds waiting for and parsing the next request. Despite its
+name, `write_timeout` currently bounds the handler future; the subsequent
+response send does not have a separate server-side timeout in version 0.5.
 
-These checks are not an atomic compare-and-delete operation: safe standard-library APIs leave a residual race if another process can replace the path after the final metadata check. Put production sockets in a trusted parent directory that untrusted users cannot modify.
+## Listener options
 
-#### Best Practices
-```bash
-# Ensure socket directory exists and has proper permissions
-sudo mkdir -p /var/run/my_app
-sudo chown $USER:$USER /var/run/my_app
-
-# Use service-specific paths
-CUSTOM_SOCK=/var/run/my_app/api.sock
-
-# Development vs production paths
-# Development: /tmp/dev_app.sock
-# Production: /var/run/production/app.sock
-```
-
-### Windows (Named Pipes)
-
-#### Advantages
-- **Native Windows IPC**: Optimized for Windows kernel architecture
-- **Security Integration**: Integrates with Windows security model
-- **Service Communication**: Excellent for Windows service communication
-- **Cross-Session**: Can communicate across user sessions when configured
-
-#### Configuration
-- **Default Path**: `\\.\\pipe\\example`
-- **Namespace**: Uses the `\\.\\pipe\\` namespace
-- **Security**: Named pipes reject remote clients by default; custom SDDL is applied to every instance
+### Unix cleanup, overwrite, and mode
 
 ```rust
-let server = IpcHttpServer::new(r"\\.\pipe\example")?
-    .with_listener_security_descriptor("D:(A;;GA;;;WD)");
+#[cfg(unix)]
+let options = kode_bridge::ListenerOptions::new()
+    .reclaim_name(true)
+    .try_overwrite(true)
+    .max_spin_time(std::time::Duration::from_millis(100));
+
+#[cfg(all(unix, not(target_os = "macos")))]
+let options = options.mode(0o660);
 ```
 
-Invalid SDDL is rejected immediately by the builder. The default client retains Tokio's identification-level security quality-of-service settings.
+- `reclaim_name(true)` is the default.
+- `try_overwrite(false)` is the default.
+- Explicit overwrite refuses non-socket paths and live listeners.
+- Custom mode currently returns `Unsupported` on macOS.
+- Use a trusted parent directory because metadata-check then remove is not an
+  atomic compare-and-delete operation.
 
-#### Best Practices
-```cmd
-REM Use descriptive pipe names
-set CUSTOM_PIPE=\\.\\pipe\\my_app_api
+### Windows SDDL
 
-REM Service-specific naming
-set CUSTOM_PIPE=\\.\\pipe\\clash_monitoring
-set CUSTOM_PIPE=\\.\\pipe\\system_metrics
-
-REM PowerShell configuration
-$env:CUSTOM_PIPE="\\.\\pipe\\my_service"
+```rust
+#[cfg(windows)]
+let options = kode_bridge::ListenerOptions::new()
+    .security_descriptor("D:(A;;GA;;;WD)");
 ```
 
-### Performance Characteristics
+The descriptor is parsed when configuring the builder and applied to every
+pipe instance. Invalid SDDL panics for compatibility with the 0.4 API. Prefer a
+least-privilege descriptor; `WD` grants access to Everyone and should not be a
+copy-paste production default.
 
-#### Connection Pool Performance
-| Platform | Pool Efficiency | Connection Reuse | Throughput |
-|----------|----------------|------------------|------------|
-| Unix     | Excellent      | 95%+             | High       |
-| Windows  | Very Good      | 90%+             | High       |
+## Operational checks
 
-#### Benchmark Results
+- Confirm the client and server resolve exactly the same endpoint string.
+- Ensure the Unix socket parent exists and has the intended ownership.
+- Treat `Address already in use` as a live-listener or stale-path decision;
+  enable overwrite only when that policy is intentional.
+- On Windows, distinguish an absent pipe from `ERROR_PIPE_BUSY`; kode-bridge
+  waits asynchronously for busy instances. High-level requests apply their
+  request timeout, while direct stream connects and preheating need an
+  application-owned cancellation boundary.
+- Exercise service identity and ACL behavior with the actual privileged and
+  unprivileged accounts used in production.
+
+## Benchmark configuration
+
 ```bash
-# Unix typically shows:
-# - Higher connection reuse rates
-# - Lower latency for frequent requests
-# - Better streaming performance
-
-# Windows shows:
-# - Stable performance across scenarios
-# - Good security integration
-# - Reliable service communication
+cargo bench --all-features --bench bench_version
+cargo bench --all-features --bench ipc_transport
 ```
+
+Criterion results are machine-specific. Keep the endpoint generator, payload,
+sample parameters, toolchain, and host unchanged when comparing versions.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,135 +1,146 @@
 # Quick Start Guide
 
-This guide helps you get started with kode-bridge quickly across all platforms.
+kode-bridge provides HTTP-style request/response and streaming APIs over Unix
+domain sockets on Unix platforms and named pipes on Windows. Version 0.5
+requires Rust 1.87 or newer.
 
-## 🚀 Quick Start Examples
-
-### Modern API Examples
-```bash
-# 🌟 Essential Examples
-cargo run --example request              # Basic HTTP requests with modern API
-cargo run --example request_large        # Large data handling and optimization
-cargo run --example modern_example       # Complete modern API overview
-
-# 🎨 Advanced Examples
-cargo run --example elegant_http         # Full HTTP client feature demonstration
-cargo run --example elegant_stream       # Complete streaming client showcase
-cargo run --example two_clients          # Architecture comparison and best practices
-cargo run --example traffic              # Professional traffic monitoring implementation
-```
-
-### Server Examples
-```bash
-# HTTP server examples (requires server feature)
-cargo run --example http_server --features server
-
-# Streaming server examples (requires server feature)
-cargo run --example stream_server --features server
-```
-
-### Legacy Compatibility
-```bash
-# All examples support both modern fluent API and legacy methods
-# for seamless migration and backward compatibility
-```
-
-## 📊 Performance Benchmarks
-
-### Running Benchmarks
-```bash
-# Run all performance benchmarks
-cargo bench
-
-# View detailed benchmark reports
-open target/criterion/report/index.html  # macOS/Linux
-start target/criterion/report/index.html # Windows
-```
-
-### Benchmark Features
-- **Cross-platform optimization**: Automatic platform-specific tuning
-- **Connection pooling performance**: Demonstrates pooling benefits
-- **Streaming vs Request/Response**: Performance comparison
-- **Error handling overhead**: Modern error system benchmarks
-
-## 🔧 Basic Setup
-
-### Dependencies
-Add to your `Cargo.toml`:
+## Add the dependency
 
 ```toml
 [dependencies]
 # Client only (default)
 kode-bridge = "0.5"
 
-# Server only  
-kode-bridge = { version = "0.5", features = ["server"] }
-
 # Both client and server
 kode-bridge = { version = "0.5", features = ["full"] }
 
-# Required runtime
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+serde_json = "1"
 ```
 
-### Available Features
-- **`client`** (default) - HTTP and streaming client functionality
-- **`server`** - HTTP and streaming server functionality  
-- **`full`** - Both client and server capabilities
+Available crate features:
 
-### Basic Client Usage
+- `client` (default): HTTP and streaming clients
+- `server`: HTTP and streaming servers
+- `full`: both `client` and `server`
+
+## Choose an endpoint
+
 ```rust
-use kode_bridge::{IpcHttpClient, IpcStreamClient};
-use serde_json::json;
+#[cfg(unix)]
+const IPC_ENDPOINT: &str = "/tmp/my-service.sock";
+
+#[cfg(windows)]
+const IPC_ENDPOINT: &str = r"\\.\pipe\my-service";
+```
+
+The library validates the endpoint but does not read `CUSTOM_SOCK` or
+`CUSTOM_PIPE` itself. Those environment variables are conventions used by the
+repository examples.
+
+## HTTP client
+
+```rust
+use kode_bridge::{IpcHttpClient, Result};
 use std::time::Duration;
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Automatically detect platform and use appropriate IPC path
+async fn main() -> Result<()> {
     #[cfg(unix)]
-    let ipc_path = "/tmp/my_service.sock";
+    let endpoint = "/tmp/my-service.sock";
     #[cfg(windows)]
-    let ipc_path = r"\\.\pipe\my_service";
-    
-    // HTTP-style client for request/response
-    let client = IpcHttpClient::new(ipc_path)?;
-    
-    // 🔥 New fluent API - like reqwest!
+    let endpoint = r"\\.\pipe\my-service";
+
+    let client = IpcHttpClient::new(endpoint)?;
     let response = client
         .get("/api/version")
         .timeout(Duration::from_secs(5))
         .send()
         .await?;
-    
-    println!("Status: {}", response.status());
-    println!("Success: {}", response.is_success());
-    
+
+    println!("status={} body={}", response.status(), response.body()?);
     Ok(())
 }
 ```
 
-### Basic Server Usage
+The fluent client supports GET, POST, PUT, DELETE, PATCH, HEAD, and OPTIONS,
+headers, JSON bodies, per-request timeouts, pooling, and typed JSON responses.
+
+## HTTP server
+
+Enable `server` or `full`, then create a router:
+
 ```rust
-use kode_bridge::{IpcHttpServer, Router, HttpResponse, Result};
+use kode_bridge::{HttpResponse, IpcHttpServer, Result, Router};
 use serde_json::json;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Create HTTP server with routing
+    #[cfg(unix)]
+    let endpoint = "/tmp/my-service.sock";
+    #[cfg(windows)]
+    let endpoint = r"\\.\pipe\my-service";
+
     let router = Router::new()
-        .get("/health", |_| async move {
+        .get("/health", |_| async {
             HttpResponse::json(&json!({"status": "healthy"}))
         })
-        .post("/api/data", |ctx| async move {
-            let data: serde_json::Value = ctx.json()?;
-            HttpResponse::json(&json!({"received": data}))
+        .post("/echo", |ctx| async move {
+            HttpResponse::json(&ctx.json::<serde_json::Value>()?)
         });
 
-    let mut server = IpcHttpServer::new("/tmp/server.sock")?
-        .router(router);
-    
-    println!("🚀 Server listening on /tmp/server.sock");
+    let mut server = IpcHttpServer::new(endpoint)?.router(router);
     server.serve().await
 }
 ```
+
+Run the checked-in server examples with:
+
+```bash
+cargo run --features server --example http_server
+cargo run --features server --example stream_server
+```
+
+## Client examples
+
+The examples read `CUSTOM_SOCK` on Unix and `CUSTOM_PIPE` on Windows:
+
+```bash
+# Unix
+CUSTOM_SOCK=/tmp/my-service.sock cargo run --example request
+
+# Windows PowerShell
+$env:CUSTOM_PIPE='\\.\pipe\my-service'
+cargo run --example request
+```
+
+Other useful examples include `request_large`, `elegant_http`,
+`elegant_stream`, `traffic`, `traffic_monitor`, and `two_clients`.
+
+## Streaming APIs
+
+- `IpcStreamClient` sends an HTTP-style request and processes a streamed HTTP
+  response line by line or as JSON values.
+- `IpcStreamServer` broadcasts raw newline-delimited `StreamMessage` frames to
+  connected IPC clients.
+
+They use different wire shapes in 0.5 and should not be assumed to connect
+directly to one another. See the checked-in examples and
+[Server Guide](../SERVER_GUIDE.md) for the current server API.
+
+## Run checks and benchmarks
+
+```bash
+cargo test --all-features
+cargo doc --all-features --no-deps
+
+cargo bench --all-features --bench bench_version
+cargo bench --all-features --bench ipc_transport
+```
+
+Criterion writes HTML reports below `target/criterion/`. Benchmark results are
+host- and platform-specific; use the same machine, toolchain, build mode, and
+parameters for before/after comparisons.
+
+For a 0.4 upgrade, continue with the
+[0.4 to 0.5 Migration Guide](./migration-guide.md).

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -59,13 +59,13 @@ Add to your `Cargo.toml`:
 ```toml
 [dependencies]
 # Client only (default)
-kode-bridge = "0.1"
+kode-bridge = "0.5"
 
 # Server only  
-kode-bridge = { version = "0.1", features = ["server"] }
+kode-bridge = { version = "0.5", features = ["server"] }
 
 # Both client and server
-kode-bridge = { version = "0.1", features = ["full"] }
+kode-bridge = { version = "0.5", features = ["full"] }
 
 # Required runtime
 tokio = { version = "1", features = ["full"] }

--- a/docs/server-development.md
+++ b/docs/server-development.md
@@ -1,426 +1,167 @@
-# Server Development Guide
+# Server Development Notes
 
-Complete guide for developing servers with kode-bridge.
+This document supplements the [Server Guide](../SERVER_GUIDE.md) with the
+current kode-bridge 0.5 handler, lifecycle, and testing contracts. It avoids
+duplicating the complete runnable examples in `examples/`.
 
-## 🚀 Server Features
+## Handler contract
 
-### HTTP Server (`IpcHttpServer`)
-- **Express.js-style routing**: Familiar patterns for web developers
-- **Middleware support**: Request/response interceptors
-- **JSON handling**: Automatic serialization/deserialization
-- **Error handling**: Structured error responses
-- **Static file serving**: Built-in static content support
-- **Request context**: Rich request information access
+A `Router` handler is a `Send + Sync + 'static` function that returns a `Send`
+future with `kode_bridge::Result<HttpResponse>`.
 
-### Streaming Server (`IpcStreamServer`)
-- **Real-time broadcasting**: Push data to multiple clients
-- **Client lifecycle management**: Connection tracking and cleanup
-- **Multiple data formats**: JSON, text, binary support
-- **Backpressure handling**: Automatic client lag detection
-- **Custom data sources**: Pluggable data generation
-
-## 📋 HTTP Server Examples
-
-### Basic HTTP Server
 ```rust
-use kode_bridge::{IpcHttpServer, Router, HttpResponse, RequestContext, Result};
-use serde_json::json;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    let router = Router::new()
-        .get("/", |_| async move {
-            HttpResponse::ok("Welcome to kode-bridge server!")
-        })
-        .get("/health", |_| async move {
-            HttpResponse::json(&json!({
-                "status": "healthy",
-                "timestamp": chrono::Utc::now().to_rfc3339()
-            }))
-        })
-        .post("/api/echo", |ctx| async move {
-            let body: serde_json::Value = ctx.json()?;
-            HttpResponse::json(&json!({
-                "echo": body,
-                "method": ctx.method(),
-                "path": ctx.path()
-            }))
-        });
-
-    let mut server = IpcHttpServer::new("/tmp/example.sock")?
-        .router(router);
-    
-    println!("🚀 Server listening on /tmp/example.sock");
-    server.serve().await
-}
-```
-
-### Advanced HTTP Server with Middleware
-```rust
-use kode_bridge::{IpcHttpServer, Router, HttpResponse, RequestContext, Result};
-use serde_json::json;
-use std::time::Instant;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    let router = Router::new()
-        // Middleware: Request logging
-        .middleware(|ctx, next| async move {
-            let start = Instant::now();
-            println!("→ {} {}", ctx.method(), ctx.path());
-            
-            let response = next(ctx).await;
-            
-            let duration = start.elapsed();
-            println!("← {} {} ({:?})", 
-                response.status(), ctx.path(), duration);
-            
-            response
-        })
-        // Routes
-        .get("/api/users/:id", |ctx| async move {
-            let user_id = ctx.param("id").unwrap_or("unknown");
-            HttpResponse::json(&json!({
-                "user_id": user_id,
-                "name": format!("User {}", user_id)
-            }))
-        })
-        .post("/api/users", |ctx| async move {
-            #[derive(serde::Deserialize)]
-            struct CreateUser {
-                name: String,
-                email: String,
-            }
-            
-            let user: CreateUser = ctx.json()?;
-            
-            // Simulate user creation
-            let new_user = json!({
-                "id": 123,
-                "name": user.name,
-                "email": user.email,
-                "created_at": chrono::Utc::now().to_rfc3339()
-            });
-            
-            HttpResponse::json(&new_user).status(201)
-        })
-        .put("/api/config", |ctx| async move {
-            let config: serde_json::Value = ctx.json()?;
-            
-            // Validate configuration
-            if config.get("version").is_none() {
-                return HttpResponse::bad_request("Missing version field");
-            }
-            
-            HttpResponse::json(&json!({
-                "message": "Configuration updated",
-                "config": config
-            }))
-        })
-        .delete("/api/cache", |_| async move {
-            // Simulate cache clearing
-            tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-            
-            HttpResponse::json(&json!({
-                "message": "Cache cleared successfully"
-            }))
-        });
-
-    let mut server = IpcHttpServer::new("/tmp/api_server.sock")?
-        .router(router)
-        .max_connections(100)
-        .request_timeout(std::time::Duration::from_secs(30));
-    
-    println!("🚀 API Server listening on /tmp/api_server.sock");
-    server.serve().await
-}
-```
-
-## 📡 Streaming Server Examples
-
-### Basic Streaming Server
-```rust
-use kode_bridge::{IpcStreamServer, StreamSource, Result};
-use serde_json::json;
-use tokio::time::{interval, Duration};
-use tokio_stream::wrappers::IntervalStream;
-use tokio_stream::StreamExt;
-
-struct MetricsSource;
-
-#[async_trait::async_trait]
-impl StreamSource for MetricsSource {
-    async fn generate_stream(&self) -> Result<Box<dyn Stream<Item = String> + Send + Unpin>> {
-        let stream = IntervalStream::new(interval(Duration::from_secs(1)))
-            .map(|_| {
-                let metrics = json!({
-                    "cpu_usage": rand::random::<f64>() * 100.0,
-                    "memory_usage": rand::random::<f64>() * 100.0,
-                    "timestamp": chrono::Utc::now().to_rfc3339()
-                });
-                metrics.to_string()
-            });
-        
-        Ok(Box::new(stream))
-    }
-}
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    let mut server = IpcStreamServer::new("/tmp/metrics.sock")?
-        .add_source("/metrics", Box::new(MetricsSource))
-        .client_timeout(Duration::from_secs(60));
-    
-    println!("📡 Streaming server listening on /tmp/metrics.sock");
-    server.serve().await
-}
-```
-
-### Advanced Streaming Server with Multiple Sources
-```rust
-use kode_bridge::{IpcStreamServer, StreamSource, Result};
-use serde_json::json;
-use tokio::time::{interval, Duration};
-use tokio_stream::wrappers::IntervalStream;
-use tokio_stream::StreamExt;
-use std::sync::Arc;
-use tokio::sync::RwLock;
-
-// Traffic monitoring source
-struct TrafficSource {
-    counters: Arc<RwLock<(u64, u64)>>, // (upload, download)
-}
-
-#[async_trait::async_trait]
-impl StreamSource for TrafficSource {
-    async fn generate_stream(&self) -> Result<Box<dyn Stream<Item = String> + Send + Unpin>> {
-        let counters = self.counters.clone();
-        
-        let stream = IntervalStream::new(interval(Duration::from_millis(500)))
-            .map(move |_| {
-                let counters = counters.clone();
-                async move {
-                    let mut guard = counters.write().await;
-                    guard.0 += rand::random::<u64>() % 1000000; // Random upload
-                    guard.1 += rand::random::<u64>() % 2000000; // Random download
-                    
-                    let traffic = json!({
-                        "upload": guard.0,
-                        "download": guard.1,
-                        "upload_rate": rand::random::<u64>() % 10000,
-                        "download_rate": rand::random::<u64>() % 20000,
-                        "timestamp": chrono::Utc::now().to_rfc3339()
-                    });
-                    
-                    traffic.to_string()
-                }
-            })
-            .then(|future| future);
-        
-        Ok(Box::new(stream))
-    }
-}
-
-// System events source
-struct EventsSource;
-
-#[async_trait::async_trait]
-impl StreamSource for EventsSource {
-    async fn generate_stream(&self) -> Result<Box<dyn Stream<Item = String> + Send + Unpin>> {
-        let events = vec![
-            "connection_established",
-            "data_processed", 
-            "cache_miss",
-            "cache_hit",
-            "error_recovered",
-            "backup_completed",
-        ];
-        
-        let stream = IntervalStream::new(interval(Duration::from_secs(2)))
-            .map(move |_| {
-                let event_type = &events[rand::random::<usize>() % events.len()];
-                let event = json!({
-                    "type": event_type,
-                    "severity": if event_type.contains("error") { "high" } else { "normal" },
-                    "message": format!("Event: {}", event_type),
-                    "timestamp": chrono::Utc::now().to_rfc3339()
-                });
-                event.to_string()
-            });
-        
-        Ok(Box::new(stream))
-    }
-}
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    let traffic_counters = Arc::new(RwLock::new((0u64, 0u64)));
-    
-    let mut server = IpcStreamServer::new("/tmp/monitoring.sock")?
-        .add_source("/traffic", Box::new(TrafficSource {
-            counters: traffic_counters.clone()
+let router = kode_bridge::Router::new()
+    .put("/config/:section", |ctx| async move {
+        let section = ctx
+            .path_params
+            .get("section")
+            .cloned()
+            .unwrap_or_default();
+        let value: serde_json::Value = ctx.json()?;
+        kode_bridge::HttpResponse::json(&serde_json::json!({
+            "section": section,
+            "value": value,
         }))
-        .add_source("/events", Box::new(EventsSource))
-        .add_source("/metrics", Box::new(MetricsSource))
-        .client_timeout(Duration::from_secs(120))
-        .max_clients(50);
-    
-    println!("📡 Monitoring server listening on /tmp/monitoring.sock");
-    println!("Available streams:");
-    println!("  /traffic - Real-time traffic data");
-    println!("  /events  - System events");
-    println!("  /metrics - Performance metrics");
-    
-    server.serve().await
-}
+    });
 ```
 
-## 🛠️ Server Configuration
+The router supports literal paths and `:name` parameters. It rejects traversal,
+backslashes, control characters, paths without a leading slash, and paths over
+2048 bytes before dispatch.
 
-### HTTP Server Configuration
+There is no middleware registry in version 0.5. Share behavior through normal
+Rust functions, captured `Arc` state, or application-owned handler wrappers.
+
+## Error boundaries
+
+Malformed request bytes, size limits, read timeouts, handler errors, and
+response writes are distinct boundaries. A handler that wants a structured
+client error should convert validation failures to an `HttpResponse`
+explicitly:
+
 ```rust
-use kode_bridge::{IpcHttpServer, ServerConfig};
-use std::time::Duration;
+use http::StatusCode;
+use kode_bridge::HttpResponse;
 
-let config = ServerConfig {
-    max_connections: 200,
-    request_timeout: Duration::from_secs(30),
-    keep_alive_timeout: Duration::from_secs(60),
-    max_request_size: 1024 * 1024, // 1MB
-    enable_compression: true,
+let response = match ctx.json::<serde_json::Value>() {
+    Ok(value) => HttpResponse::json(&value)?,
+    Err(error) => HttpResponse::error(StatusCode::BAD_REQUEST, &error.to_string()),
 };
-
-let mut server = IpcHttpServer::with_config("/tmp/server.sock", config)?
-    .router(router);
 ```
 
-### Streaming Server Configuration  
+Do not set a short server `write_timeout` if a handler intentionally performs a
+slow local lifecycle operation. Despite the field name, version 0.5 applies it
+to handler completion and does not wrap `framed.send(response)` in a separate
+write timeout. Slow handlers and slow response readers are therefore different
+performance and reliability boundaries.
+
+## Connection ownership
+
+The HTTP server acquires a connection permit before accepting the next client.
+Each accepted connection can serve up to
+`ServerConfig::max_requests_per_connection` requests. A client pool may open a
+replacement connection after that limit; this is expected behavior.
+
+Configure:
+
+- `max_connections` for concurrent open connections;
+- `max_requests_per_connection` for keep-alive lifetime;
+- `read_timeout` for the next request on an open connection;
+- `write_timeout` for handler completion (not the later response write);
+- `max_header_size` and `max_request_size` for memory limits.
+
+## Shared state
+
+Handlers are called concurrently. Capture shared state using an `Arc` and an
+appropriate synchronization primitive. Do not hold a synchronous lock guard
+across `.await`.
+
 ```rust
-use kode_bridge::{IpcStreamServer, StreamServerConfig};
-use std::time::Duration;
+use std::sync::{Arc, atomic::{AtomicU64, Ordering}};
 
-let config = StreamServerConfig {
-    max_clients: 100,
-    client_timeout: Duration::from_secs(300),
-    buffer_size: 65536,
-    heartbeat_interval: Duration::from_secs(30),
-    lag_threshold: Duration::from_secs(10),
-};
-
-let mut server = IpcStreamServer::with_config("/tmp/stream.sock", config)?;
-```
-
-## 🔒 Error Handling and Security
-
-### Structured Error Responses
-```rust
-use kode_bridge::{HttpResponse, KodeBridgeError};
-
-// Custom error handling
-.post("/api/validate", |ctx| async move {
-    let data: serde_json::Value = match ctx.json() {
-        Ok(data) => data,
-        Err(e) => {
-            return HttpResponse::bad_request(&format!("Invalid JSON: {}", e));
-        }
-    };
-    
-    // Validate required fields
-    if data.get("required_field").is_none() {
-        return HttpResponse::unprocessable_entity("Missing required_field");
-    }
-    
-    HttpResponse::ok("Validation passed")
-})
-```
-
-### Input Validation and Sanitization
-```rust
-use serde::{Deserialize, Serialize};
-
-#[derive(Deserialize)]
-struct UserInput {
-    #[serde(deserialize_with = "validate_username")]
-    username: String,
-    
-    #[serde(deserialize_with = "validate_email")]
-    email: String,
-}
-
-fn validate_username<'de, D>(deserializer: D) -> Result<String, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let username = String::deserialize(deserializer)?;
-    
-    if username.len() < 3 || username.len() > 20 {
-        return Err(serde::de::Error::custom("Username must be 3-20 characters"));
-    }
-    
-    if !username.chars().all(|c| c.is_alphanumeric() || c == '_') {
-        return Err(serde::de::Error::custom("Username contains invalid characters"));
-    }
-    
-    Ok(username)
-}
-```
-
-## 📈 Performance Optimization
-
-### Connection Management
-```rust
-// Optimize for high-concurrency scenarios
-let mut server = IpcHttpServer::new("/tmp/server.sock")?
-    .max_connections(500)  // Increase concurrent connections
-    .request_timeout(Duration::from_secs(15))  // Shorter timeout
-    .keep_alive_timeout(Duration::from_secs(30));  // Connection reuse
-```
-
-### Memory Management
-```rust
-// For streaming servers with high throughput
-let mut server = IpcStreamServer::new("/tmp/stream.sock")?
-    .buffer_size(128 * 1024)  // 128KB buffer for high-volume data
-    .max_clients(200)         // Limit clients to prevent memory exhaustion
-    .lag_threshold(Duration::from_secs(5));  // Disconnect slow clients
-```
-
-### Monitoring and Metrics
-```rust
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
-
-#[derive(Clone)]
-struct ServerMetrics {
-    requests_total: Arc<AtomicU64>,
-    requests_success: Arc<AtomicU64>,
-    requests_error: Arc<AtomicU64>,
-}
-
-impl ServerMetrics {
-    fn new() -> Self {
-        Self {
-            requests_total: Arc::new(AtomicU64::new(0)),
-            requests_success: Arc::new(AtomicU64::new(0)),
-            requests_error: Arc::new(AtomicU64::new(0)),
+let requests = Arc::new(AtomicU64::new(0));
+let router = kode_bridge::Router::new().get("/count", {
+    let requests = Arc::clone(&requests);
+    move |_| {
+        let requests = Arc::clone(&requests);
+        async move {
+            let count = requests.fetch_add(1, Ordering::Relaxed) + 1;
+            kode_bridge::HttpResponse::json(&serde_json::json!({"count": count}))
         }
     }
-    
-    fn record_request(&self, success: bool) {
-        self.requests_total.fetch_add(1, Ordering::Relaxed);
-        if success {
-            self.requests_success.fetch_add(1, Ordering::Relaxed);
-        } else {
-            self.requests_error.fetch_add(1, Ordering::Relaxed);
-        }
-    }
-    
-    fn get_stats(&self) -> (u64, u64, u64) {
-        (
-            self.requests_total.load(Ordering::Relaxed),
-            self.requests_success.load(Ordering::Relaxed),
-            self.requests_error.load(Ordering::Relaxed),
-        )
-    }
-}
+});
 ```
+
+## Streaming sources
+
+`IpcStreamServer::serve_with_source` owns one `StreamSource`. The source
+lifecycle is:
+
+1. `initialize()` before accepting clients;
+2. repeated `next_messages()` calls while `has_more()` is true;
+3. `cleanup()` when the source loop exits normally.
+
+Cancelling the server task can abort the source task before `cleanup()` runs.
+Put mandatory resource cleanup in owned values with `Drop`, not only in the
+async source hook.
+
+Messages are sent through a Tokio broadcast channel. When a receiver lags, the
+channel reports and skips the missed messages; a write error or write timeout
+ends that client connection. Size and write-timeout limits still apply.
+`JsonDataSource` is suitable for periodic generation; `IteratorSource` adapts
+a Tokio stream of `StreamMessage` values.
+
+The stream server emits raw frames. Do not use `IpcStreamClient` as its direct
+peer without an HTTP response layer; the two public types intentionally retain
+their pre-0.5 wire behavior.
+
+## Listener lifecycle
+
+On Unix, listener drop removes only the socket path whose device/inode identity
+matches the socket created by that listener. Explicit stale overwrite performs
+a liveness check and refuses regular files, but the final metadata-check/remove
+pair is not atomic. Use a trusted socket directory.
+
+On Windows, each accepted pipe instance is replaced with the next pending
+instance before the connected stream is handed upward. The configured SDDL is
+reused for every instance. Final dirty writes are flushed independently of
+request-future cancellation.
+
+Task cancellation must be awaited before immediate restart so listener drop
+and endpoint cleanup have completed.
+
+## Testing server code
+
+The repository's transport integration suite demonstrates reliable readiness
+without sleep-based startup guesses:
+
+```bash
+cargo test --all-features --test ipc_transport
+cargo test --all-features
+```
+
+When adding server behavior, cover at least:
+
+- method, header, query, path-parameter, and body handling;
+- keep-alive reuse and the per-connection request limit;
+- duplicate listener and restart behavior;
+- request timeout and cancellation followed by a healthy request;
+- 32 concurrent clients on each supported platform;
+- Unix mode, stale socket, and cleanup policy;
+- Windows SDDL, pipe-busy, final-response flush, and drop delivery.
+
+Run real Linux, macOS, and Windows jobs for transport changes. Cross-compilation
+proves type compatibility, not socket or named-pipe runtime behavior.
+
+## Performance work
+
+Use the frozen Criterion suites before changing hot paths:
+
+```bash
+cargo bench --all-features --bench bench_version
+cargo bench --all-features --bench ipc_transport
+```
+
+Keep the same host, toolchain, payloads, sample settings, and endpoint strategy
+for before/after comparisons. Inspect confidence intervals and throughput;
+single wall-clock runs are not sufficient evidence.

--- a/src/ipc_http_client.rs
+++ b/src/ipc_http_client.rs
@@ -1,9 +1,6 @@
 use std::path::Path;
 use std::time::Duration;
 
-use interprocess::local_socket::tokio::prelude::LocalSocketStream;
-use interprocess::local_socket::traits::tokio::Stream as _;
-use interprocess::local_socket::{GenericFilePath, Name, ToFsName as _};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 
@@ -12,6 +9,7 @@ use crate::http_client::{send_request, RequestBuilder, Response};
 use crate::metrics::global_metrics;
 use crate::pool::{ConnectionPool, PoolConfig, PooledConnection};
 use crate::retry::{RetryConfig, RetryExecutor};
+use crate::transport::{Endpoint, IpcStream};
 use bytes::Bytes;
 use http::Method;
 use std::str::FromStr as _;
@@ -54,7 +52,7 @@ impl Default for ClientConfig {
 /// This client is optimized for request-response patterns with connection pooling support.
 /// For streaming functionality, use `IpcStreamClient` instead.
 pub struct IpcHttpClient {
-    name: Name<'static>,
+    endpoint: Endpoint,
     config: ClientConfig,
     pool: Option<ConnectionPool>,
     retry_executor: RetryExecutor,
@@ -171,14 +169,10 @@ impl IpcHttpClient {
     where
         P: AsRef<Path>,
     {
-        let name = path
-            .as_ref()
-            .to_fs_name::<GenericFilePath>()
-            .map_err(|e| KodeBridgeError::configuration(format!("Invalid path: {}", e)))?
-            .into_owned();
+        let endpoint = Endpoint::new(path)?;
 
         let pool = if config.enable_pooling {
-            Some(ConnectionPool::new(name.clone(), config.pool_config.clone()))
+            Some(ConnectionPool::new(endpoint.clone(), config.pool_config.clone()))
         } else {
             None
         };
@@ -195,7 +189,7 @@ impl IpcHttpClient {
         let put_retry_executor = RetryExecutor::new(put_retry_config);
 
         Ok(Self {
-            name,
+            endpoint,
             config,
             pool,
             retry_executor,
@@ -204,7 +198,7 @@ impl IpcHttpClient {
     }
 
     /// Create a direct connection (bypassing pool)
-    async fn create_direct_connection(&self) -> Result<LocalSocketStream> {
+    async fn create_direct_connection(&self) -> Result<IpcStream> {
         let mut last_error = None;
 
         for attempt in 0..self.config.max_retries {
@@ -212,7 +206,7 @@ impl IpcHttpClient {
                 tokio::time::sleep(self.config.retry_delay).await;
             }
 
-            match LocalSocketStream::connect(self.name.clone()).await {
+            match IpcStream::connect(&self.endpoint).await {
                 Ok(stream) => {
                     debug!("Created direct connection on attempt {}", attempt + 1);
                     return Ok(stream);
@@ -234,7 +228,7 @@ impl IpcHttpClient {
     }
 
     /// Get a connection (from pool or create new)
-    async fn get_connection(&self) -> Result<Either<PooledConnection, LocalSocketStream>> {
+    async fn get_connection(&self) -> Result<Either<PooledConnection, IpcStream>> {
         let metrics = global_metrics();
 
         if let Some(ref pool) = self.pool {
@@ -412,9 +406,7 @@ impl IpcHttpClient {
     }
 
     /// Get a fresh connection optimized for PUT requests
-    async fn get_fresh_connection(&self) -> Result<Either<PooledConnection, LocalSocketStream>> {
-        use interprocess::local_socket::tokio::prelude::LocalSocketStream;
-
+    async fn get_fresh_connection(&self) -> Result<Either<PooledConnection, IpcStream>> {
         // 首先尝试从连接池获取新连接
         if let Some(ref pool) = self.pool {
             match tokio::time::timeout(Duration::from_millis(20), pool.get_fresh_connection()).await {
@@ -426,12 +418,7 @@ impl IpcHttpClient {
         }
 
         // 直接创建连接，使用更快的超时设置
-        match tokio::time::timeout(
-            Duration::from_millis(100),
-            LocalSocketStream::connect(self.name.clone()),
-        )
-        .await
-        {
+        match tokio::time::timeout(Duration::from_millis(100), IpcStream::connect(&self.endpoint)).await {
             Ok(Ok(stream)) => Ok(Either::Direct(stream)),
             Ok(Err(_)) | Err(_) => {
                 // 如果直接连接失败，回退到普通池化连接

--- a/src/ipc_http_server.rs
+++ b/src/ipc_http_server.rs
@@ -5,20 +5,10 @@
 
 use crate::codec::HttpIpcCodec;
 use crate::errors::{KodeBridgeError, Result};
+use crate::transport::{Endpoint, Listener, ListenerOptions, ServerStream};
 use bytes::Bytes;
 use futures::{SinkExt as _, StreamExt as _};
 use http::{HeaderMap, Method, StatusCode, Uri};
-use interprocess::local_socket::{
-    tokio::prelude::LocalSocketStream, traits::tokio::Listener as _, GenericFilePath, ListenerOptions, Name,
-    ToFsName as _,
-};
-#[cfg(unix)]
-use interprocess::os::unix::local_socket::ListenerOptionsExt as _;
-#[cfg(windows)]
-use interprocess::os::windows::local_socket::ListenerOptionsExt as _;
-#[cfg(windows)]
-use interprocess::os::windows::security_descriptor::SecurityDescriptor;
-use interprocess::TryClone as _;
 use path_tree::PathTree;
 use std::{
     collections::HashMap,
@@ -34,8 +24,6 @@ use tokio::{sync::Semaphore, time::timeout};
 use tokio_util::codec::Framed;
 use tracing::{debug, error, info, warn};
 use url::Url;
-#[cfg(windows)]
-use widestring::U16CString;
 
 /// Configuration for HTTP IPC server
 #[derive(Debug, Clone, Copy)]
@@ -426,9 +414,9 @@ impl fmt::Display for ServerStats {
 
 /// High-level HTTP IPC server
 pub struct IpcHttpServer {
-    name: Name<'static>,
+    endpoint: Endpoint,
     config: ServerConfig,
-    listener_options: ListenerOptions<'static>,
+    listener_options: ListenerOptions,
     router: Arc<Router>,
     stats: Arc<SharedStats>,
     connection_semaphore: Arc<Semaphore>,
@@ -437,15 +425,11 @@ pub struct IpcHttpServer {
 
 impl IpcHttpServer {
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let name = path
-            .as_ref()
-            .to_fs_name::<GenericFilePath>()
-            .map_err(|e| KodeBridgeError::configuration(format!("Invalid server path: {}", e)))?
-            .into_owned();
+        let endpoint = Endpoint::new(path)?;
         let config = ServerConfig::default();
         let listener_options = ListenerOptions::new();
         Ok(Self {
-            name,
+            endpoint,
             config,
             listener_options,
             router: Arc::new(Router::new()),
@@ -456,15 +440,11 @@ impl IpcHttpServer {
     }
 
     pub fn with_config<P: AsRef<Path>>(path: P, config: ServerConfig) -> Result<Self> {
-        let name = path
-            .as_ref()
-            .to_fs_name::<GenericFilePath>()
-            .map_err(|e| KodeBridgeError::configuration(format!("Invalid server path: {}", e)))?
-            .into_owned();
+        let endpoint = Endpoint::new(path)?;
         let connection_semaphore = Arc::new(Semaphore::new(config.max_connections));
         let listener_options = ListenerOptions::new();
         Ok(Self {
-            name,
+            endpoint,
             config,
             listener_options,
             router: Arc::new(Router::new()),
@@ -474,22 +454,27 @@ impl IpcHttpServer {
         })
     }
 
-    pub fn with_listener_options(mut self, options: ListenerOptions<'static>) -> Self {
+    #[cfg(unix)]
+    pub const fn with_listener_options(mut self, options: ListenerOptions) -> Self {
+        self.listener_options = options;
+        self
+    }
+
+    #[cfg(windows)]
+    pub fn with_listener_options(mut self, options: ListenerOptions) -> Self {
         self.listener_options = options;
         self
     }
 
     #[cfg(unix)]
-    pub fn with_listener_mode(mut self, mode: libc::mode_t) -> Self {
+    pub const fn with_listener_mode(mut self, mode: libc::mode_t) -> Self {
         self.listener_options = self.listener_options.mode(mode);
         self
     }
 
     #[cfg(windows)]
     pub fn with_listener_security_descriptor(mut self, sddl: &str) -> Self {
-        let sddl = U16CString::from_str(sddl).expect("Invalid SDDL string");
-        let sd = SecurityDescriptor::deserialize(&sddl).expect("Failed to parse SDDL");
-        self.listener_options = self.listener_options.security_descriptor(sd);
+        self.listener_options = self.listener_options.security_descriptor(sddl);
         self
     }
 
@@ -510,12 +495,9 @@ impl IpcHttpServer {
     }
 
     pub async fn serve(&mut self) -> Result<()> {
-        let listener_options = self.listener_options.try_clone()?;
-        let listener = listener_options
-            .name(self.name.clone())
-            .create_tokio()
+        let mut listener = Listener::bind(&self.endpoint, &self.listener_options)
             .map_err(|e| KodeBridgeError::connection(format!("Failed to bind server: {}", e)))?;
-        info!("🚀 HTTP IPC Server listening on {:?}", self.name);
+        info!("🚀 HTTP IPC Server listening on {:?}", self.endpoint);
 
         // TODO: Graceful shutdown handling with custom signal
         let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
@@ -601,7 +583,7 @@ impl IpcHttpServer {
     }
 
     async fn handle_connection(
-        stream: LocalSocketStream,
+        stream: ServerStream,
         connection_id: u64,
         router: Arc<Router>,
         config: ServerConfig,
@@ -716,7 +698,7 @@ impl IpcHttpServer {
 impl fmt::Debug for IpcHttpServer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("IpcHttpServer")
-            .field("name", &self.name)
+            .field("endpoint", &self.endpoint)
             .field("config", &self.config)
             .field("stats", &self.stats)
             .finish()

--- a/src/ipc_http_server.rs
+++ b/src/ipc_http_server.rs
@@ -618,7 +618,11 @@ impl IpcHttpServer {
                 Err(e) => {
                     error!("Failed to parse request: {}", e);
                     let response = HttpResponse::error(StatusCode::BAD_REQUEST, "Bad Request");
-                    let _ = framed.send(response).await;
+                    match timeout(config.write_timeout, framed.send(response)).await {
+                        Ok(Ok(())) => {}
+                        Ok(Err(error)) => return Err(error),
+                        Err(_) => return Err(KodeBridgeError::timeout_msg("Response write timeout")),
+                    }
                     stats.total_errors.fetch_add(1, Ordering::Relaxed);
                     continue;
                 }
@@ -666,17 +670,22 @@ impl IpcHttpServer {
             };
 
             let status_code = response.status;
-            match framed.send(response).await {
-                Ok(_) => {
+            match timeout(config.write_timeout, framed.send(response)).await {
+                Ok(Ok(())) => {
                     stats.total_responses.fetch_add(1, Ordering::Relaxed);
                     if config.enable_logging {
                         info!("✅ {} {} - {}", method, uri, status_code);
                     }
                 }
-                Err(e) => {
-                    error!("Failed to write response: {}", e);
+                Ok(Err(error)) => {
+                    error!("Failed to write response: {}", error);
                     stats.total_errors.fetch_add(1, Ordering::Relaxed);
-                    return Err(e);
+                    return Err(error);
+                }
+                Err(_) => {
+                    error!("Response write timeout");
+                    stats.total_errors.fetch_add(1, Ordering::Relaxed);
+                    return Err(KodeBridgeError::timeout_msg("Response write timeout"));
                 }
             }
 

--- a/src/ipc_stream_client.rs
+++ b/src/ipc_stream_client.rs
@@ -1,15 +1,13 @@
 use std::path::Path;
 use std::time::Duration;
 
-use interprocess::local_socket::tokio::prelude::LocalSocketStream;
-use interprocess::local_socket::traits::tokio::Stream as _;
-use interprocess::local_socket::{GenericFilePath, Name, ToFsName as _};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
 
 use crate::errors::{KodeBridgeError, Result};
 use crate::http_client::RequestBuilder;
 use crate::stream_client::{send_streaming_request, StreamingResponse};
+use crate::transport::{Endpoint, IpcStream};
 use http::Method;
 use std::str::FromStr as _;
 use tracing::{debug, trace};
@@ -40,7 +38,7 @@ impl Default for StreamClientConfig {
 
 /// Specialized IPC streaming client for handling real-time data streams
 pub struct IpcStreamClient {
-    name: Name<'static>,
+    endpoint: Endpoint,
     config: StreamClientConfig,
 }
 
@@ -156,17 +154,13 @@ impl IpcStreamClient {
     where
         P: AsRef<Path>,
     {
-        let name = path
-            .as_ref()
-            .to_fs_name::<GenericFilePath>()
-            .map_err(|e| KodeBridgeError::configuration(format!("Invalid path: {}", e)))?
-            .into_owned();
+        let endpoint = Endpoint::new(path)?;
 
-        Ok(Self { name, config })
+        Ok(Self { endpoint, config })
     }
 
     /// Create a connection with retry logic
-    async fn create_connection(&self) -> Result<LocalSocketStream> {
+    async fn create_connection(&self) -> Result<IpcStream> {
         let mut last_error = None;
 
         for attempt in 0..self.config.max_retries {
@@ -174,7 +168,7 @@ impl IpcStreamClient {
                 tokio::time::sleep(self.config.retry_delay).await;
             }
 
-            match LocalSocketStream::connect(self.name.clone()).await {
+            match IpcStream::connect(&self.endpoint).await {
                 Ok(stream) => {
                     debug!("Created streaming connection on attempt {}", attempt + 1);
                     return Ok(stream);

--- a/src/ipc_stream_server.rs
+++ b/src/ipc_stream_server.rs
@@ -4,20 +4,8 @@
 //! real-time data to multiple clients with different streaming patterns.
 
 use crate::errors::{KodeBridgeError, Result};
+use crate::transport::{Endpoint, Listener, ListenerOptions, ServerStream};
 use bytes::Bytes;
-#[cfg(unix)]
-use interprocess::os::unix::local_socket::ListenerOptionsExt as _;
-#[cfg(windows)]
-use interprocess::os::windows::local_socket::ListenerOptionsExt as _;
-#[cfg(windows)]
-use interprocess::os::windows::security_descriptor::SecurityDescriptor;
-use interprocess::{
-    local_socket::{
-        tokio::prelude::LocalSocketStream, traits::tokio::Listener as _, GenericFilePath, ListenerOptions, Name,
-        ToFsName as _,
-    },
-    TryClone as _,
-};
 use parking_lot::RwLock;
 use serde_json::Value;
 use std::{
@@ -39,8 +27,6 @@ use tokio::{
 };
 use tokio_stream::{Stream, StreamExt as _};
 use tracing::{debug, error, info, warn};
-#[cfg(windows)]
-use widestring::U16CString;
 
 /// Configuration for streaming IPC server
 #[derive(Debug, Clone)]
@@ -340,9 +326,9 @@ where
 
 /// High-level streaming IPC server
 pub struct IpcStreamServer {
-    name: Name<'static>,
+    endpoint: Endpoint,
     config: StreamServerConfig,
-    listener_options: ListenerOptions<'static>,
+    listener_options: ListenerOptions,
     stats: Arc<RwLock<StreamServerStats>>,
     connection_semaphore: Arc<Semaphore>,
     clients: Arc<RwLock<HashMap<u64, StreamClient>>>,
@@ -354,11 +340,7 @@ pub struct IpcStreamServer {
 impl IpcStreamServer {
     /// Create a new streaming IPC server
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let name = path
-            .as_ref()
-            .to_fs_name::<GenericFilePath>()
-            .map_err(|e| KodeBridgeError::configuration(format!("Invalid server path: {}", e)))?
-            .into_owned();
+        let endpoint = Endpoint::new(path)?;
 
         let config = StreamServerConfig::default();
         let connection_semaphore = Arc::new(Semaphore::new(config.max_connections));
@@ -366,7 +348,7 @@ impl IpcStreamServer {
         let listener_options = ListenerOptions::new();
 
         Ok(Self {
-            name,
+            endpoint,
             config,
             listener_options,
             stats: Arc::new(RwLock::new(StreamServerStats::new())),
@@ -380,18 +362,14 @@ impl IpcStreamServer {
 
     /// Create a new streaming IPC server with custom configuration
     pub fn with_config<P: AsRef<Path>>(path: P, config: StreamServerConfig) -> Result<Self> {
-        let name = path
-            .as_ref()
-            .to_fs_name::<GenericFilePath>()
-            .map_err(|e| KodeBridgeError::configuration(format!("Invalid server path: {}", e)))?
-            .into_owned();
+        let endpoint = Endpoint::new(path)?;
 
         let connection_semaphore = Arc::new(Semaphore::new(config.max_connections));
 
         let listener_options = ListenerOptions::new();
 
         Ok(Self {
-            name,
+            endpoint,
             config,
             listener_options,
             stats: Arc::new(RwLock::new(StreamServerStats::new())),
@@ -403,7 +381,14 @@ impl IpcStreamServer {
         })
     }
 
-    pub fn with_listener_options(mut self, options: ListenerOptions<'static>) -> Self {
+    #[cfg(unix)]
+    pub const fn with_listener_options(mut self, options: ListenerOptions) -> Self {
+        self.listener_options = options;
+        self
+    }
+
+    #[cfg(windows)]
+    pub fn with_listener_options(mut self, options: ListenerOptions) -> Self {
         self.listener_options = options;
         self
     }
@@ -420,7 +405,7 @@ impl IpcStreamServer {
     /// let server = IpcStreamServer::new("/tmp/my.sock").unwrap().with_listener_mode(0o660); // Only owner and group can read/write
     /// ```
     #[cfg(unix)]
-    pub fn with_listener_mode(mut self, mode: libc::mode_t) -> Self {
+    pub const fn with_listener_mode(mut self, mode: libc::mode_t) -> Self {
         self.listener_options = self.listener_options.mode(mode);
         self
     }
@@ -448,9 +433,7 @@ impl IpcStreamServer {
     /// See [Microsoft SDDL documentation](https://learn.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-string-format)
     #[cfg(windows)]
     pub fn with_listener_security_descriptor(mut self, sddl: &str) -> Self {
-        let sddl = U16CString::from_str(sddl).expect("Invalid SDDL string");
-        let sd = SecurityDescriptor::deserialize(&sddl).expect("Failed to parse SDDL");
-        self.listener_options = self.listener_options.security_descriptor(sd);
+        self.listener_options = self.listener_options.security_descriptor(sddl);
         self
     }
 
@@ -485,13 +468,10 @@ impl IpcStreamServer {
         let (broadcast_tx, _) = broadcast::channel(self.config.broadcast_capacity);
         self.broadcast_tx = Some(broadcast_tx.clone());
 
-        let listener_options = self.listener_options.try_clone()?;
-        let listener = listener_options
-            .name(self.name.clone())
-            .create_tokio()
+        let mut listener = Listener::bind(&self.endpoint, &self.listener_options)
             .map_err(|e| KodeBridgeError::connection(format!("Failed to bind server: {}", e)))?;
 
-        info!("🌊 Stream IPC Server listening on {:?}", self.name);
+        info!("🌊 Stream IPC Server listening on {:?}", self.endpoint);
 
         // Initialize data source
         source.initialize().await?;
@@ -677,7 +657,7 @@ impl IpcStreamServer {
     /// Handle a single streaming client connection
     #[allow(clippy::cognitive_complexity)]
     async fn handle_stream_client(
-        mut stream: LocalSocketStream,
+        mut stream: ServerStream,
         client_id: u64,
         mut broadcast_rx: broadcast::Receiver<StreamMessage>,
         config: StreamServerConfig,
@@ -780,7 +760,7 @@ impl IpcStreamServer {
 impl fmt::Debug for IpcStreamServer {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("IpcStreamServer")
-            .field("name", &self.name)
+            .field("endpoint", &self.endpoint)
             .field("config", &self.config)
             .field("stats", &self.stats)
             .finish()

--- a/src/ipc_stream_server.rs
+++ b/src/ipc_stream_server.rs
@@ -434,8 +434,14 @@ impl IpcStreamServer {
     /// Will panic if the SDDL string is invalid or cannot be parsed.
     ///
     /// # Example
-    /// ```rust
-    /// server = server.with_listener_security_descriptor("D:(A;;GA;;;WD)"); // Allow Everyone access
+    /// ```no_run
+    /// use kode_bridge::{IpcStreamServer, Result};
+    ///
+    /// # fn main() -> Result<()> {
+    /// let server = IpcStreamServer::new(r"\\.\pipe\kode-bridge-stream")?;
+    /// let _server = server.with_listener_security_descriptor("D:(A;;GA;;;WD)");
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// # Reference

--- a/src/ipc_stream_server.rs
+++ b/src/ipc_stream_server.rs
@@ -125,6 +125,21 @@ impl StreamMessage {
     }
 }
 
+#[derive(Clone)]
+enum BroadcastMessage {
+    Data(Bytes),
+    Close,
+}
+
+impl From<StreamMessage> for BroadcastMessage {
+    fn from(message: StreamMessage) -> Self {
+        match message {
+            StreamMessage::Close => Self::Close,
+            message => Self::Data(message.to_bytes()),
+        }
+    }
+}
+
 /// Client connection information for streaming
 #[derive(Debug, Clone)]
 pub struct StreamClient {
@@ -257,15 +272,15 @@ impl JsonDataSource {
 impl StreamSource for JsonDataSource {
     fn next_messages(&mut self) -> Pin<Box<dyn Future<Output = Result<Vec<StreamMessage>>> + Send + '_>> {
         Box::pin(async move {
-            let now = Instant::now();
-            if now.duration_since(self.last_generated) >= self.interval {
-                self.last_generated = now;
-                match (self.generator)() {
-                    Ok(value) => Ok(vec![StreamMessage::Json(value)]),
-                    Err(e) => Err(e),
-                }
-            } else {
-                Ok(vec![])
+            let deadline = self.last_generated + self.interval;
+            if self.interval > Duration::ZERO && Instant::now() < deadline {
+                tokio::time::sleep_until(tokio::time::Instant::from_std(deadline)).await;
+            }
+
+            self.last_generated = Instant::now();
+            match (self.generator)() {
+                Ok(value) => Ok(vec![StreamMessage::Json(value)]),
+                Err(error) => Err(error),
             }
         })
     }
@@ -286,6 +301,7 @@ impl StreamSource for JsonDataSource {
 /// Stream from an async iterator
 pub struct IteratorSource<S> {
     stream: S,
+    exhausted: bool,
 }
 
 impl<S> IteratorSource<S>
@@ -294,7 +310,10 @@ where
 {
     /// Create a new iterator source
     pub const fn new(stream: S) -> Self {
-        Self { stream }
+        Self {
+            stream,
+            exhausted: false,
+        }
     }
 }
 
@@ -306,13 +325,16 @@ where
         Box::pin(async move {
             match self.stream.next().await {
                 Some(message) => Ok(vec![message]),
-                None => Ok(vec![]),
+                None => {
+                    self.exhausted = true;
+                    Ok(vec![])
+                }
             }
         })
     }
 
     fn has_more(&self) -> bool {
-        true // Stream sources are considered to always have potential data
+        !self.exhausted
     }
 
     fn initialize(&mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
@@ -333,7 +355,7 @@ pub struct IpcStreamServer {
     connection_semaphore: Arc<Semaphore>,
     clients: Arc<RwLock<HashMap<u64, StreamClient>>>,
     client_id_counter: Arc<AtomicU64>,
-    broadcast_tx: Option<broadcast::Sender<StreamMessage>>,
+    broadcast_tx: Option<broadcast::Sender<BroadcastMessage>>,
     shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
 }
 
@@ -450,7 +472,7 @@ impl IpcStreamServer {
     /// Broadcast a message to all connected clients
     pub fn broadcast(&self, message: StreamMessage) -> Result<usize> {
         if let Some(ref tx) = self.broadcast_tx {
-            match tx.send(message) {
+            match tx.send(message.into()) {
                 Ok(_) => Ok(tx.receiver_count()),
                 Err(_) => Err(KodeBridgeError::connection("No active receivers")),
             }
@@ -497,7 +519,7 @@ impl IpcStreamServer {
                             Ok(messages) => {
                                 let message_count = messages.len() as u64;
                                 for message in messages {
-                                    if source_broadcast_tx.send(message).is_err() {
+                                    if source_broadcast_tx.send(message.into()).is_err() {
                                         debug!("No receivers for broadcast message");
                                     }
                                 }
@@ -524,8 +546,7 @@ impl IpcStreamServer {
                     }
                 }
 
-                // Small delay to prevent tight loops
-                tokio::time::sleep(Duration::from_millis(10)).await;
+                tokio::task::yield_now().await;
             }
 
             // Cleanup source
@@ -619,7 +640,7 @@ impl IpcStreamServer {
         source_task.abort();
 
         // Send close message to all clients
-        let _ = broadcast_tx.send(StreamMessage::Close);
+        let _ = broadcast_tx.send(BroadcastMessage::Close);
 
         // Wait for active connections to finish
         let start = Instant::now();
@@ -659,7 +680,7 @@ impl IpcStreamServer {
     async fn handle_stream_client(
         mut stream: ServerStream,
         client_id: u64,
-        mut broadcast_rx: broadcast::Receiver<StreamMessage>,
+        mut broadcast_rx: broadcast::Receiver<BroadcastMessage>,
         config: StreamServerConfig,
         stats: Arc<RwLock<StreamServerStats>>,
         clients: Arc<RwLock<HashMap<u64, StreamClient>>>,
@@ -675,27 +696,24 @@ impl IpcStreamServer {
                     match msg_result {
                         Ok(message) => {
                             match message {
-                                StreamMessage::Close => {
+                                BroadcastMessage::Close => {
                                     debug!("Received close message for client {}", client_id);
                                     break;
                                 }
-                                _ => {
-                                    // Send message to client
-                                    let data = message.to_bytes();
-
+                                BroadcastMessage::Data(data) => {
                                     if data.len() > config.max_message_size {
                                         warn!("Message too large for client {}, skipping", client_id);
                                         continue;
                                     }
 
-                                    match timeout(config.write_timeout, stream.write_all(&data)).await {
+                                    match timeout(config.write_timeout, async {
+                                        stream.write_all(&data).await?;
+                                        stream.flush().await
+                                    }).await {
                                         Ok(Ok(())) => {
-                                            if stream.flush().await.is_ok() {
-                                                // Update client stats
-                                                if let Some(client) = clients.write().get_mut(&client_id) {
-                                                    client.messages_sent += 1;
-                                                    client.last_activity = Instant::now();
-                                                }
+                                            if let Some(client) = clients.write().get_mut(&client_id) {
+                                                client.messages_sent += 1;
+                                                client.last_activity = Instant::now();
                                             }
                                         }
                                         Ok(Err(e)) => {
@@ -738,14 +756,19 @@ impl IpcStreamServer {
                         last_keepalive = now;
 
                         let ping_data = StreamMessage::Ping.to_bytes();
-                        if let Err(e) = timeout(config.write_timeout, stream.write_all(&ping_data)).await {
-                            warn!("Failed to send keepalive to client {}: {:?}", client_id, e);
-                            break;
-                        }
-
-                        if let Err(e) = stream.flush().await {
-                            warn!("Failed to flush keepalive to client {}: {}", client_id, e);
-                            break;
+                        match timeout(config.write_timeout, async {
+                            stream.write_all(&ping_data).await?;
+                            stream.flush().await
+                        }).await {
+                            Ok(Ok(())) => {}
+                            Ok(Err(error)) => {
+                                warn!("Failed to send keepalive to client {}: {}", client_id, error);
+                                break;
+                            }
+                            Err(_) => {
+                                warn!("Keepalive write timeout for client {}", client_id);
+                                break;
+                            }
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@ pub mod parser_cache;
 pub mod pool;
 pub mod response;
 pub mod retry;
+mod transport;
+
+pub use transport::{Endpoint, IpcStream, ListenerOptions};
 
 #[cfg(feature = "client")]
 pub mod ipc_http_client;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -195,7 +195,7 @@ impl LatencyTracker {
         Some(sum / self.samples.len() as u32)
     }
 
-    pub fn count(&self) -> usize {
+    pub const fn count(&self) -> usize {
         self.samples.len()
     }
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,7 +1,5 @@
 use crate::errors::{KodeBridgeError, Result};
-use interprocess::local_socket::tokio::prelude::LocalSocketStream;
-use interprocess::local_socket::traits::tokio::Stream as _;
-use interprocess::local_socket::Name;
+use crate::transport::{Endpoint, IpcStream};
 use parking_lot::Mutex;
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -64,7 +62,7 @@ impl PoolConfig {
 
 /// A pooled connection wrapper
 pub struct PooledConnection {
-    inner: Option<LocalSocketStream>,
+    inner: Option<IpcStream>,
     permit: Option<OwnedSemaphorePermit>,
     created_at: Instant,
     last_used: Instant,
@@ -73,7 +71,7 @@ pub struct PooledConnection {
 }
 
 impl PooledConnection {
-    fn new(stream: LocalSocketStream, permit: OwnedSemaphorePermit, pool: Arc<ConnectionPoolInner>) -> Self {
+    fn new(stream: IpcStream, permit: OwnedSemaphorePermit, pool: Arc<ConnectionPoolInner>) -> Self {
         let now = Instant::now();
         Self {
             inner: Some(stream),
@@ -86,13 +84,13 @@ impl PooledConnection {
     }
 
     /// Get the underlying stream
-    pub fn stream(&mut self) -> Option<&mut LocalSocketStream> {
+    pub fn stream(&mut self) -> Option<&mut IpcStream> {
         self.last_used = Instant::now();
         self.inner.as_mut()
     }
 
     /// Take ownership of the underlying stream
-    pub fn into_stream(mut self) -> Option<LocalSocketStream> {
+    pub fn into_stream(mut self) -> Option<IpcStream> {
         self.reusable = false;
         if let Some(permit) = self.permit.take() {
             self.pool
@@ -135,14 +133,14 @@ impl Drop for PooledConnection {
 }
 
 struct IdleConnection {
-    stream: LocalSocketStream,
+    stream: IpcStream,
     last_used: Instant,
     permit: OwnedSemaphorePermit,
 }
 
 /// Internal pool state with PUT request optimization
 struct ConnectionPoolInner {
-    name: Name<'static>,
+    endpoint: Endpoint,
     config: PoolConfig,
     connections: Mutex<VecDeque<IdleConnection>>,
     semaphore: Arc<Semaphore>,
@@ -151,9 +149,9 @@ struct ConnectionPoolInner {
 }
 
 impl ConnectionPoolInner {
-    fn new(name: Name<'static>, config: PoolConfig) -> Self {
+    fn new(endpoint: Endpoint, config: PoolConfig) -> Self {
         Self {
-            name,
+            endpoint,
             semaphore: Arc::new(Semaphore::new(config.max_size)),
             connections: Mutex::new(VecDeque::new()),
             active_connections: std::sync::atomic::AtomicUsize::new(0),
@@ -162,14 +160,14 @@ impl ConnectionPoolInner {
     }
 
     /// Get a fresh connection for PUT requests, bypassing normal pool
-    async fn get_fresh_connection(&self) -> Result<LocalSocketStream> {
+    async fn get_fresh_connection(&self) -> Result<IpcStream> {
         let mut last_error = None;
         for attempt in 0..2 {
             if attempt > 0 {
                 tokio::time::sleep(Duration::from_millis(10)).await;
             }
 
-            match LocalSocketStream::connect(self.name.clone()).await {
+            match IpcStream::connect(&self.endpoint).await {
                 Ok(stream) => {
                     debug!("Created fresh connection for PUT request");
                     return Ok(stream);
@@ -197,7 +195,7 @@ impl ConnectionPoolInner {
                 break;
             };
 
-            match LocalSocketStream::connect(self.name.clone()).await {
+            match IpcStream::connect(&self.endpoint).await {
                 Ok(stream) => {
                     self.connections.lock().push_back(IdleConnection {
                         stream,
@@ -217,7 +215,7 @@ impl ConnectionPoolInner {
         }
     }
 
-    async fn create_connection(&self) -> Result<LocalSocketStream> {
+    async fn create_connection(&self) -> Result<IpcStream> {
         let mut last_error = None;
         let mut delay = self.config.retry_delay();
         let max_delay = Duration::from_millis(200); // 限制最大延迟为200ms
@@ -229,7 +227,7 @@ impl ConnectionPoolInner {
                 delay = std::cmp::min(delay * 2, max_delay);
             }
 
-            match LocalSocketStream::connect(self.name.clone()).await {
+            match IpcStream::connect(&self.endpoint).await {
                 Ok(stream) => {
                     debug!("Created new connection on attempt {}", attempt + 1);
                     return Ok(stream);
@@ -249,7 +247,7 @@ impl ConnectionPoolInner {
         )))
     }
 
-    fn get_pooled_connection(&self) -> Option<(LocalSocketStream, OwnedSemaphorePermit)> {
+    fn get_pooled_connection(&self) -> Option<(IpcStream, OwnedSemaphorePermit)> {
         let mut connections = self.connections.lock();
 
         let now = Instant::now();
@@ -267,7 +265,7 @@ impl ConnectionPoolInner {
         })
     }
 
-    fn return_connection(&self, stream: LocalSocketStream, permit: OwnedSemaphorePermit, reusable: bool) {
+    fn return_connection(&self, stream: IpcStream, permit: OwnedSemaphorePermit, reusable: bool) {
         self.active_connections
             .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
 
@@ -307,15 +305,15 @@ pub struct ConnectionPool {
 
 impl ConnectionPool {
     /// Create a new connection pool
-    pub fn new(name: Name<'static>, config: PoolConfig) -> Self {
+    pub fn new(endpoint: Endpoint, config: PoolConfig) -> Self {
         Self {
-            inner: Arc::new(ConnectionPoolInner::new(name, config)),
+            inner: Arc::new(ConnectionPoolInner::new(endpoint, config)),
         }
     }
 
     /// Create a connection pool with default configuration
-    pub fn with_default_config(name: Name<'static>) -> Self {
-        Self::new(name, PoolConfig::default())
+    pub fn with_default_config(endpoint: Endpoint) -> Self {
+        Self::new(endpoint, PoolConfig::default())
     }
 
     /// Get a connection from the pool

--- a/src/retry.rs
+++ b/src/retry.rs
@@ -1,5 +1,5 @@
 use crate::errors::KodeBridgeError;
-use rand::{random_range, rngs::StdRng, SeedableRng as _};
+use rand::random_range;
 use std::time::{Duration, Instant};
 use tracing::{debug, warn};
 
@@ -230,7 +230,6 @@ impl RetryExecutor {
         T: Send,
     {
         let mut state = RetryState::new();
-        let mut rng = StdRng::from_seed([0u8; 32]); // Use deterministic seed for Send compatibility
 
         loop {
             state.attempt += 1;
@@ -271,7 +270,7 @@ impl RetryExecutor {
                     }
 
                     // Calculate next delay
-                    let next_delay = self.calculate_delay(&mut state, &mut rng);
+                    let next_delay = self.calculate_delay(&mut state);
 
                     debug!(
                         "Retrying after {}ms (attempt {}/{}, error: {})",
@@ -351,7 +350,7 @@ impl RetryExecutor {
     }
 
     /// Calculate next retry delay with backoff and jitter
-    fn calculate_delay(&self, state: &mut RetryState, _rng: &mut impl rand::Rng) -> Duration {
+    fn calculate_delay(&self, state: &mut RetryState) -> Duration {
         let base_delay = match self.config.backoff_strategy {
             BackoffStrategy::Fixed => self.config.base_delay,
             BackoffStrategy::Exponential { multiplier } => {
@@ -623,7 +622,6 @@ mod tests {
     #[test]
     fn test_backoff_strategies() {
         let mut state = RetryState::new();
-        let mut rng = StdRng::from_seed([0u8; 32]); // Use deterministic seed for Send compatibility
 
         // Test exponential backoff
         let config = RetryConfig::new()
@@ -633,15 +631,15 @@ mod tests {
         let executor = RetryExecutor::new(config);
 
         state.attempt = 1;
-        let delay1 = executor.calculate_delay(&mut state, &mut rng);
+        let delay1 = executor.calculate_delay(&mut state);
         assert_eq!(delay1, Duration::from_millis(100));
 
         state.attempt = 2;
-        let delay2 = executor.calculate_delay(&mut state, &mut rng);
+        let delay2 = executor.calculate_delay(&mut state);
         assert_eq!(delay2, Duration::from_millis(200));
 
         state.attempt = 3;
-        let delay3 = executor.calculate_delay(&mut state, &mut rng);
+        let delay3 = executor.calculate_delay(&mut state);
         assert_eq!(delay3, Duration::from_millis(400));
     }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,0 +1,206 @@
+use crate::errors::{KodeBridgeError, Result};
+use std::io::IoSlice;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+#[cfg(unix)]
+mod unix;
+#[cfg(windows)]
+mod windows;
+
+#[cfg(unix)]
+use unix as platform;
+#[cfg(windows)]
+use windows as platform;
+
+/// A validated cross-platform IPC endpoint.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Endpoint(PathBuf);
+
+impl Endpoint {
+    /// Validate and own an IPC endpoint path.
+    pub fn new(path: impl AsRef<Path>) -> Result<Self> {
+        platform::validate_endpoint(path.as_ref())
+            .map_err(|error| KodeBridgeError::configuration(format!("Invalid IPC endpoint: {error}")))?;
+        Ok(Self(path.as_ref().to_path_buf()))
+    }
+
+    /// Return the platform endpoint path.
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for Endpoint {
+    fn as_ref(&self) -> &Path {
+        self.as_path()
+    }
+}
+
+/// Cross-platform IPC listener configuration.
+#[derive(Clone, Debug)]
+pub struct ListenerOptions {
+    reclaim_name: bool,
+    try_overwrite: bool,
+    #[cfg(unix)]
+    max_spin_time: Option<Duration>,
+    #[cfg(unix)]
+    mode: Option<libc::mode_t>,
+    #[cfg(windows)]
+    security_descriptor: Option<std::sync::Arc<windows::SecurityDescriptor>>,
+}
+
+impl ListenerOptions {
+    /// Return the default listener configuration.
+    pub const fn new() -> Self {
+        Self {
+            reclaim_name: true,
+            try_overwrite: false,
+            #[cfg(unix)]
+            max_spin_time: None,
+            #[cfg(unix)]
+            mode: None,
+            #[cfg(windows)]
+            security_descriptor: None,
+        }
+    }
+
+    /// Configure whether the endpoint name is removed when the listener drops.
+    #[must_use]
+    pub const fn reclaim_name(mut self, reclaim_name: bool) -> Self {
+        self.reclaim_name = reclaim_name;
+        self
+    }
+
+    /// Configure whether a proven-stale Unix socket may be replaced while binding.
+    #[must_use]
+    pub const fn try_overwrite(mut self, try_overwrite: bool) -> Self {
+        self.try_overwrite = try_overwrite;
+        self
+    }
+
+    /// Bound retry time for Unix stale-socket replacement contention.
+    #[must_use]
+    #[cfg_attr(not(unix), allow(unused_mut))]
+    pub const fn max_spin_time(mut self, max_spin_time: Duration) -> Self {
+        #[cfg(unix)]
+        {
+            self.max_spin_time = Some(max_spin_time);
+        }
+        let _ = max_spin_time;
+        self
+    }
+
+    /// Set Unix socket permissions before the listener begins accepting clients.
+    #[cfg(unix)]
+    #[must_use]
+    pub const fn mode(mut self, mode: libc::mode_t) -> Self {
+        self.mode = Some(mode);
+        self
+    }
+
+    /// Set a Windows named-pipe security descriptor from SDDL.
+    ///
+    /// # Panics
+    /// Panics with `Invalid SDDL string` for an interior NUL, or with
+    /// `Failed to parse SDDL` when Windows rejects the descriptor.
+    #[cfg(windows)]
+    #[must_use]
+    #[allow(clippy::panic)]
+    pub fn security_descriptor(mut self, sddl: &str) -> Self {
+        if sddl.encode_utf16().any(|unit| unit == 0) {
+            panic!("Invalid SDDL string");
+        }
+        let descriptor = match windows::SecurityDescriptor::from_sddl(sddl) {
+            Ok(descriptor) => descriptor,
+            Err(error) => panic!("Failed to parse SDDL: {error}"),
+        };
+        self.security_descriptor = Some(std::sync::Arc::new(descriptor));
+        self
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use super::ListenerOptions;
+
+    #[test]
+    #[should_panic(expected = "Invalid SDDL string")]
+    fn interior_nul_keeps_legacy_panic_classification() {
+        let _options = ListenerOptions::new().security_descriptor("D:\0(A;;GA;;;WD)");
+    }
+
+    #[test]
+    #[should_panic(expected = "Failed to parse SDDL")]
+    fn malformed_sddl_keeps_legacy_panic_classification() {
+        let _options = ListenerOptions::new().security_descriptor("not-valid-sddl");
+    }
+}
+
+impl Default for ListenerOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Client-side stream returned by kode-bridge IPC connections.
+#[derive(Debug)]
+pub struct IpcStream(platform::ClientStream);
+
+impl IpcStream {
+    pub(crate) async fn connect(endpoint: &Endpoint) -> std::io::Result<Self> {
+        platform::connect(endpoint.as_path()).await.map(Self)
+    }
+}
+
+impl AsyncRead for IpcStream {
+    fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buffer: &mut ReadBuf<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().0).poll_read(cx, buffer)
+    }
+}
+
+impl AsyncWrite for IpcStream {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buffer: &[u8]) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.get_mut().0).poll_write(cx, buffer)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffers: &[IoSlice<'_>],
+    ) -> Poll<std::io::Result<usize>> {
+        Pin::new(&mut self.get_mut().0).poll_write_vectored(cx, buffers)
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.0.is_write_vectored()
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().0).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Pin::new(&mut self.get_mut().0).poll_shutdown(cx)
+    }
+}
+
+#[cfg(feature = "server")]
+pub(crate) type ServerStream = platform::ServerStream;
+
+#[cfg(feature = "server")]
+pub(crate) struct Listener(platform::Listener);
+
+#[cfg(feature = "server")]
+impl Listener {
+    pub(crate) fn bind(endpoint: &Endpoint, options: &ListenerOptions) -> std::io::Result<Self> {
+        platform::Listener::bind(endpoint.as_path(), options).map(Self)
+    }
+
+    pub(crate) async fn accept(&mut self) -> std::io::Result<ServerStream> {
+        self.0.accept().await
+    }
+}

--- a/src/transport/unix.rs
+++ b/src/transport/unix.rs
@@ -39,8 +39,8 @@ pub(super) async fn connect(path: &Path) -> io::Result<ClientStream> {
 
 #[cfg(feature = "server")]
 pub(crate) struct Listener {
-    inner: UnixListener,
     _path_guard: Option<SocketPathGuard>,
+    inner: UnixListener,
 }
 
 #[cfg(feature = "server")]
@@ -75,8 +75,8 @@ impl Listener {
 
         let inner = socket.listen(1024)?;
         Ok(Self {
-            inner,
             _path_guard: path_guard,
+            inner,
         })
     }
 
@@ -252,12 +252,12 @@ mod tests {
         let original = std::os::unix::net::UnixListener::bind(&guarded_path)?;
         let metadata = std::fs::symlink_metadata(&guarded_path)?;
         let guard = SocketPathGuard::new(guarded_path.clone(), &metadata);
-        drop(original);
         std::fs::remove_file(&guarded_path)?;
         let replacement = std::os::unix::net::UnixListener::bind(&guarded_path)?;
 
         drop(guard);
         assert!(guarded_path.exists());
+        drop(original);
         drop(replacement);
         std::fs::remove_file(guarded_path)?;
         Ok(())

--- a/src/transport/unix.rs
+++ b/src/transport/unix.rs
@@ -1,0 +1,265 @@
+#[cfg(feature = "server")]
+use super::ListenerOptions;
+#[cfg(feature = "server")]
+use std::fs::Metadata;
+use std::io;
+use std::os::unix::ffi::OsStrExt as _;
+#[cfg(all(feature = "server", not(target_os = "macos")))]
+use std::os::unix::fs::PermissionsExt as _;
+#[cfg(feature = "server")]
+use std::os::unix::fs::{FileTypeExt as _, MetadataExt as _};
+#[cfg(feature = "server")]
+use std::os::unix::net::UnixStream as StdUnixStream;
+use std::path::Path;
+#[cfg(feature = "server")]
+use std::path::PathBuf;
+#[cfg(feature = "server")]
+use std::time::Instant;
+use tokio::net::UnixStream;
+#[cfg(feature = "server")]
+use tokio::net::{UnixListener, UnixSocket};
+
+pub(super) type ClientStream = UnixStream;
+#[cfg(feature = "server")]
+pub(crate) type ServerStream = UnixStream;
+
+pub(super) fn validate_endpoint(path: &Path) -> io::Result<()> {
+    if path.as_os_str().as_bytes().contains(&0) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "filesystem paths cannot contain interior nuls",
+        ));
+    }
+    Ok(())
+}
+
+pub(super) async fn connect(path: &Path) -> io::Result<ClientStream> {
+    UnixStream::connect(path).await
+}
+
+#[cfg(feature = "server")]
+pub(crate) struct Listener {
+    inner: UnixListener,
+    _path_guard: Option<SocketPathGuard>,
+}
+
+#[cfg(feature = "server")]
+impl Listener {
+    pub(crate) fn bind(path: &Path, options: &ListenerOptions) -> io::Result<Self> {
+        #[cfg(target_os = "macos")]
+        if options.mode.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Unix listener mode is unsupported on macOS",
+            ));
+        }
+
+        let socket = bind_socket(path, options)?;
+        let metadata = socket_metadata(path)?;
+        let path_guard = options
+            .reclaim_name
+            .then(|| SocketPathGuard::new(path.to_path_buf(), &metadata));
+
+        #[cfg(not(target_os = "macos"))]
+        if let Some(mode) = options.mode {
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))?;
+        }
+
+        let current = socket_metadata(path)?;
+        if !same_file(&metadata, &current) {
+            return Err(io::Error::new(
+                io::ErrorKind::AddrInUse,
+                "Unix socket path changed before listen",
+            ));
+        }
+
+        let inner = socket.listen(1024)?;
+        Ok(Self {
+            inner,
+            _path_guard: path_guard,
+        })
+    }
+
+    // The Windows backend mutates its pending pipe instance during accept, so the shared
+    // transport contract intentionally keeps a mutable receiver on every platform.
+    #[allow(clippy::needless_pass_by_ref_mut)]
+    pub(crate) async fn accept(&mut self) -> io::Result<ServerStream> {
+        self.inner.accept().await.map(|(stream, _address)| stream)
+    }
+}
+
+#[cfg(feature = "server")]
+fn socket_metadata(path: &Path) -> io::Result<Metadata> {
+    let metadata = std::fs::symlink_metadata(path)?;
+    if !metadata.file_type().is_socket() {
+        return Err(io::Error::new(
+            io::ErrorKind::AddrInUse,
+            "Unix socket path no longer refers to a socket",
+        ));
+    }
+    Ok(metadata)
+}
+
+#[cfg(feature = "server")]
+fn bind_socket(path: &Path, options: &ListenerOptions) -> io::Result<UnixSocket> {
+    let started = Instant::now();
+    let mut attempted_reclaim = false;
+    loop {
+        let socket = UnixSocket::new_stream()?;
+        match socket.bind(path) {
+            Ok(()) => return Ok(socket),
+            Err(error) if error.kind() == io::ErrorKind::AddrInUse && options.try_overwrite => {
+                if attempted_reclaim
+                    && options
+                        .max_spin_time
+                        .is_some_and(|limit| started.elapsed() >= limit)
+                {
+                    return Err(error);
+                }
+                reclaim_stale_socket(path)?;
+                attempted_reclaim = true;
+                std::thread::yield_now();
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+fn reclaim_stale_socket(path: &Path) -> io::Result<()> {
+    let before = std::fs::symlink_metadata(path)?;
+    if !before.file_type().is_socket() {
+        return Err(io::Error::new(
+            io::ErrorKind::AddrInUse,
+            "refusing to replace a non-socket endpoint",
+        ));
+    }
+
+    match StdUnixStream::connect(path) {
+        Ok(_live) => {
+            return Err(io::Error::new(
+                io::ErrorKind::AddrInUse,
+                "refusing to replace a live Unix listener",
+            ));
+        }
+        Err(error) if error.kind() == io::ErrorKind::ConnectionRefused => {}
+        Err(error) => return Err(error),
+    }
+
+    let after = std::fs::symlink_metadata(path)?;
+    if !same_file(&before, &after) || !after.file_type().is_socket() {
+        return Err(io::Error::new(
+            io::ErrorKind::AddrInUse,
+            "endpoint changed while checking stale socket",
+        ));
+    }
+    std::fs::remove_file(path)
+}
+
+#[cfg(feature = "server")]
+fn same_file(left: &Metadata, right: &Metadata) -> bool {
+    left.dev() == right.dev() && left.ino() == right.ino()
+}
+
+#[cfg(feature = "server")]
+struct SocketPathGuard {
+    path: PathBuf,
+    device: u64,
+    inode: u64,
+}
+
+#[cfg(feature = "server")]
+impl SocketPathGuard {
+    fn new(path: PathBuf, metadata: &Metadata) -> Self {
+        Self {
+            path,
+            device: metadata.dev(),
+            inode: metadata.ino(),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl Drop for SocketPathGuard {
+    fn drop(&mut self) {
+        let Ok(metadata) = std::fs::symlink_metadata(&self.path) else {
+            return;
+        };
+        if metadata.file_type().is_socket() && metadata.dev() == self.device && metadata.ino() == self.inode {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+#[cfg(all(test, feature = "server"))]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static PATH_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+    fn path(label: &str) -> PathBuf {
+        let sequence = PATH_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        PathBuf::from(format!(
+            "/tmp/kb-transport-{}-{sequence}-{label}.sock",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn overwrite_reclaims_only_stale_sockets() -> io::Result<()> {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_io()
+            .build()?;
+        let _runtime_guard = runtime.enter();
+        let stale_path = path("stale");
+        let stale = std::os::unix::net::UnixListener::bind(&stale_path)?;
+        drop(stale);
+
+        let listener = Listener::bind(
+            &stale_path,
+            &ListenerOptions::new()
+                .try_overwrite(true)
+                .max_spin_time(std::time::Duration::ZERO),
+        )?;
+        drop(listener);
+        assert!(!stale_path.exists());
+
+        let file_path = path("file");
+        std::fs::write(&file_path, b"sentinel")?;
+        let result = Listener::bind(&file_path, &ListenerOptions::new().try_overwrite(true));
+        assert!(result.is_err());
+        assert_eq!(std::fs::read(&file_path)?, b"sentinel");
+        std::fs::remove_file(file_path)?;
+        Ok(())
+    }
+
+    #[test]
+    fn overwrite_refuses_live_listener() -> io::Result<()> {
+        let live_path = path("live");
+        let live = std::os::unix::net::UnixListener::bind(&live_path)?;
+        let result = Listener::bind(&live_path, &ListenerOptions::new().try_overwrite(true));
+        assert!(result.is_err());
+        assert!(live_path.exists());
+        drop(live);
+        std::fs::remove_file(live_path)?;
+        Ok(())
+    }
+
+    #[test]
+    fn guard_does_not_remove_replaced_socket() -> io::Result<()> {
+        let guarded_path = path("guard");
+        let original = std::os::unix::net::UnixListener::bind(&guarded_path)?;
+        let metadata = std::fs::symlink_metadata(&guarded_path)?;
+        let guard = SocketPathGuard::new(guarded_path.clone(), &metadata);
+        drop(original);
+        std::fs::remove_file(&guarded_path)?;
+        let replacement = std::os::unix::net::UnixListener::bind(&guarded_path)?;
+
+        drop(guard);
+        assert!(guarded_path.exists());
+        drop(replacement);
+        std::fs::remove_file(guarded_path)?;
+        Ok(())
+    }
+}

--- a/src/transport/windows.rs
+++ b/src/transport/windows.rs
@@ -427,6 +427,42 @@ mod tests {
         Ok((server, client))
     }
 
+    fn inject_pending_flush<T: AsHandle>(stream: &mut PipeStream<T>) -> oneshot::Sender<()> {
+        let (release_tx, release_rx) = oneshot::channel();
+        stream.flush = Some(tokio::spawn(async move {
+            let _ = release_rx.await;
+            Ok(())
+        }));
+        release_tx
+    }
+
+    async fn flush_and_read_payload(
+        server: &mut ServerStream,
+        client: &mut ClientStream,
+        payload: &[u8],
+        read_delay: Duration,
+    ) -> io::Result<()> {
+        let mut received = vec![0; payload.len()];
+        let complete = async {
+            tokio::try_join!(server.flush(), async {
+                tokio::time::sleep(read_delay).await;
+                client.read_exact(&mut received).await
+            })?;
+            Ok::<(), io::Error>(())
+        };
+        match tokio::time::timeout(Duration::from_secs(5), complete).await {
+            Ok(result) => result?,
+            Err(_elapsed) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "pipe flush and client read did not complete within the deadline",
+                ));
+            }
+        }
+        assert_eq!(received, payload);
+        Ok(())
+    }
+
     async fn read_payload(client: &mut ClientStream, payload: &[u8]) -> io::Result<()> {
         let mut received = vec![0; payload.len()];
         match tokio::time::timeout(Duration::from_secs(5), client.read_exact(&mut received)).await {
@@ -445,29 +481,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn flush_waits_for_a_slow_reader() -> io::Result<()> {
+    async fn explicit_flush_and_client_read_complete_with_payload() -> io::Result<()> {
         let (mut server, mut client) = connected_pair("flush").await?;
         let payload = b"final response";
         server.write_all(payload).await?;
 
-        let mut flush = Box::pin(server.flush());
-        let premature = tokio::time::timeout(Duration::from_millis(50), &mut flush).await;
-        assert!(
-            premature.is_err(),
-            "pipe flush completed before the client read buffered data"
-        );
-
-        read_payload(&mut client, payload).await?;
-        match tokio::time::timeout(Duration::from_secs(5), &mut flush).await {
-            Ok(result) => result?,
-            Err(_elapsed) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    "pipe flush did not complete after the client read the response",
-                ));
-            }
-        }
-        Ok(())
+        flush_and_read_payload(&mut server, &mut client, payload, Duration::from_millis(50)).await
     }
 
     #[tokio::test]
@@ -479,45 +498,30 @@ mod tests {
         server_one.write_all(payload_one).await?;
         server_two.write_all(payload_two).await?;
 
+        let release_one = inject_pending_flush(&mut server_one);
         let mut flush_one = Box::pin(server_one.flush());
         let flush_one_pending =
             std::future::poll_fn(|cx| Poll::Ready(std::future::Future::poll(flush_one.as_mut(), cx).is_pending()))
                 .await;
-        assert!(flush_one_pending, "first flush completed before its client read");
+        assert!(flush_one_pending, "injected first flush did not remain pending");
 
-        let mut flush_two = Box::pin(server_two.flush());
-        let flush_two_pending =
-            std::future::poll_fn(|cx| Poll::Ready(std::future::Future::poll(flush_two.as_mut(), cx).is_pending()))
+        flush_and_read_payload(&mut server_two, &mut client_two, payload_two, Duration::ZERO).await?;
+
+        let first_still_pending =
+            std::future::poll_fn(|cx| Poll::Ready(std::future::Future::poll(flush_one.as_mut(), cx).is_pending()))
                 .await;
-        assert!(flush_two_pending, "second flush completed before its client read");
-
-        read_payload(&mut client_two, payload_two).await?;
-        match tokio::time::timeout(Duration::from_secs(5), &mut flush_two).await {
-            Ok(result) => result?,
-            Err(_elapsed) => {
-                return Err(io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    "second flush was blocked by the first connection",
-                ));
-            }
-        }
-
-        let first_still_pending = tokio::time::timeout(Duration::from_millis(50), &mut flush_one).await;
-        assert!(
-            first_still_pending.is_err(),
-            "first flush completed before its client read"
-        );
-        read_payload(&mut client_one, payload_one).await?;
+        assert!(first_still_pending, "injected first flush completed before release");
+        let _ = release_one.send(());
         match tokio::time::timeout(Duration::from_secs(5), &mut flush_one).await {
             Ok(result) => result?,
             Err(_elapsed) => {
                 return Err(io::Error::new(
                     io::ErrorKind::TimedOut,
-                    "first flush did not complete after its client read",
+                    "injected first flush did not complete after release",
                 ));
             }
         }
-        Ok(())
+        read_payload(&mut client_one, payload_one).await
     }
 
     #[tokio::test]
@@ -536,12 +540,14 @@ mod tests {
         let payload = b"complete response after cancelled flush";
         server.write_all(payload).await?;
 
+        let release = inject_pending_flush(&mut server);
         let mut flush = Box::pin(server.flush());
         let pending =
             std::future::poll_fn(|cx| Poll::Ready(std::future::Future::poll(flush.as_mut(), cx).is_pending())).await;
-        assert!(pending, "pipe flush completed before the client read buffered data");
+        assert!(pending, "injected flush did not remain pending");
         drop(flush);
         drop(server);
+        drop(release);
 
         read_payload(&mut client, payload).await
     }
@@ -563,24 +569,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn thirty_two_slow_reader_flushes_complete_without_fallback_pressure() -> io::Result<()> {
+    async fn thirty_two_concurrent_flushes_and_reads_complete_without_hanging() -> io::Result<()> {
         const CLIENTS: usize = 32;
-        let payload = b"slow reader response";
+        let payload = b"concurrent response";
         let mut clients = Vec::with_capacity(CLIENTS);
         let mut started_receivers = Vec::with_capacity(CLIENTS);
         let mut flush_tasks = Vec::with_capacity(CLIENTS);
 
         for index in 0..CLIENTS {
             let (mut server, client) = connected_pair(&format!("stress-{index}")).await?;
-            server.write_all(payload).await?;
             let (started_tx, started_rx) = oneshot::channel();
             let flush_task = tokio::spawn(async move {
+                server.write_all(payload).await?;
                 let mut flush = Box::pin(server.flush());
                 let mut started_tx = Some(started_tx);
                 std::future::poll_fn(|cx| {
                     let result = std::future::Future::poll(flush.as_mut(), cx);
                     if let Some(started_tx) = started_tx.take() {
-                        let _ = started_tx.send(result.is_pending());
+                        let _ = started_tx.send(());
                     }
                     result
                 })
@@ -591,44 +597,29 @@ mod tests {
             flush_tasks.push(flush_task);
         }
 
-        for started_rx in started_receivers {
-            match tokio::time::timeout(Duration::from_secs(5), started_rx).await {
-                Ok(Ok(true)) => {}
-                Ok(Ok(false)) => {
-                    return Err(io::Error::other(
-                        "named-pipe flush completed before its slow reader consumed data",
-                    ));
-                }
-                Ok(Err(error)) => return Err(io::Error::other(error)),
-                Err(_elapsed) => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::TimedOut,
-                        "named-pipe flush did not reach its first poll",
-                    ));
-                }
+        let complete = async {
+            for started in futures::future::join_all(started_receivers).await {
+                started.map_err(io::Error::other)?;
             }
-        }
-        assert!(flush_tasks.iter().all(|task| !task.is_finished()));
 
-        let reads = clients
-            .into_iter()
-            .map(|mut client| async move { read_payload(&mut client, payload).await });
-        for result in futures::future::join_all(reads).await {
-            result?;
-        }
-
-        for flush_task in flush_tasks {
-            match tokio::time::timeout(Duration::from_secs(10), flush_task).await {
-                Ok(Ok(result)) => result?,
-                Ok(Err(error)) => return Err(io::Error::other(error)),
-                Err(_elapsed) => {
-                    return Err(io::Error::new(
-                        io::ErrorKind::TimedOut,
-                        "named-pipe flush did not complete after readers consumed every payload",
-                    ));
-                }
+            let reads = clients
+                .into_iter()
+                .map(|mut client| async move { read_payload(&mut client, payload).await });
+            for result in futures::future::join_all(reads).await {
+                result?;
             }
+
+            for result in futures::future::join_all(flush_tasks).await {
+                result.map_err(io::Error::other)??;
+            }
+            Ok::<(), io::Error>(())
+        };
+        match tokio::time::timeout(Duration::from_secs(10), complete).await {
+            Ok(result) => result,
+            Err(_elapsed) => Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "concurrent named-pipe flushes and reads did not complete within the deadline",
+            )),
         }
-        Ok(())
     }
 }

--- a/src/transport/windows.rs
+++ b/src/transport/windows.rs
@@ -1,0 +1,634 @@
+#[cfg(feature = "server")]
+use super::ListenerOptions;
+use std::ffi::{c_void, OsStr};
+use std::fmt;
+use std::fs::File;
+use std::io::{self, IoSlice};
+use std::iter;
+#[cfg(feature = "server")]
+use std::mem::size_of;
+use std::os::windows::ffi::OsStrExt as _;
+use std::os::windows::io::AsHandle;
+use std::path::Path;
+use std::pin::Pin;
+use std::ptr::NonNull;
+use std::sync::{
+    mpsc::{sync_channel, SyncSender, TrySendError},
+    Arc, Mutex, OnceLock,
+};
+use std::task::{Context, Poll};
+use std::thread;
+use std::time::Duration;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::windows::named_pipe::{ClientOptions, NamedPipeClient};
+#[cfg(feature = "server")]
+use tokio::net::windows::named_pipe::{NamedPipeServer, ServerOptions};
+use windows_sys::Win32::Foundation::{LocalFree, ERROR_PIPE_BUSY};
+use windows_sys::Win32::Security::Authorization::{
+    ConvertStringSecurityDescriptorToSecurityDescriptorW, SDDL_REVISION_1,
+};
+#[cfg(feature = "server")]
+use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
+
+pub(super) type ClientStream = PipeStream<NamedPipeClient>;
+#[cfg(feature = "server")]
+pub(crate) type ServerStream = PipeStream<NamedPipeServer>;
+
+const FLUSH_QUEUE_CAPACITY: usize = 64;
+
+// Explicit flushes use per-stream blocking tasks so one slow reader cannot stall
+// another connection. Drop linger uses the bounded queue below; saturation above
+// the 0.4 high watermark moves that job to an independent worker, while server
+// max_connections bounds normal queue exposure.
+pub(crate) struct PipeStream<T: AsHandle> {
+    inner: T,
+    dirty: bool,
+    flush: Option<tokio::task::JoinHandle<io::Result<()>>>,
+}
+
+impl<T: AsHandle> PipeStream<T> {
+    const fn new(inner: T) -> Self {
+        Self {
+            inner,
+            dirty: false,
+            flush: None,
+        }
+    }
+
+    fn poll_pending_flush(&mut self, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let Some(flush) = &mut self.flush else {
+            return Poll::Ready(Ok(()));
+        };
+        match std::future::Future::poll(Pin::new(flush), cx) {
+            Poll::Ready(Ok(Ok(()))) => {
+                self.flush = None;
+                self.dirty = false;
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Ok(Err(error))) => {
+                self.flush = None;
+                Poll::Ready(Err(error))
+            }
+            Poll::Ready(Err(error)) => {
+                self.flush = None;
+                Poll::Ready(Err(io::Error::other(format!("named pipe flush task failed: {error}"))))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn begin_flush(&mut self) -> io::Result<()> {
+        let owned_handle = self.inner.as_handle().try_clone_to_owned()?;
+        self.flush = Some(tokio::task::spawn_blocking(move || File::from(owned_handle).sync_all()));
+        Ok(())
+    }
+}
+
+impl<T> fmt::Debug for PipeStream<T>
+where
+    T: AsHandle + fmt::Debug,
+{
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("PipeStream")
+            .field("inner", &self.inner)
+            .field("dirty", &self.dirty)
+            .field("flush_pending", &self.flush.is_some())
+            .finish()
+    }
+}
+
+impl<T> AsyncRead for PipeStream<T>
+where
+    T: AsHandle + AsyncRead + Unpin,
+{
+    fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buffer: &mut ReadBuf<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().inner).poll_read(cx, buffer)
+    }
+}
+
+impl<T> AsyncWrite for PipeStream<T>
+where
+    T: AsHandle + AsyncWrite + Unpin,
+{
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buffer: &[u8]) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        match this.poll_pending_flush(cx) {
+            Poll::Ready(Ok(())) => {}
+            Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+            Poll::Pending => return Poll::Pending,
+        }
+
+        match Pin::new(&mut this.inner).poll_write(cx, buffer) {
+            Poll::Ready(Ok(written)) => {
+                this.dirty |= written != 0;
+                Poll::Ready(Ok(written))
+            }
+            result => result,
+        }
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buffers: &[IoSlice<'_>],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        match this.poll_pending_flush(cx) {
+            Poll::Ready(Ok(())) => {}
+            Poll::Ready(Err(error)) => return Poll::Ready(Err(error)),
+            Poll::Pending => return Poll::Pending,
+        }
+
+        match Pin::new(&mut this.inner).poll_write_vectored(cx, buffers) {
+            Poll::Ready(Ok(written)) => {
+                this.dirty |= written != 0;
+                Poll::Ready(Ok(written))
+            }
+            result => result,
+        }
+    }
+
+    fn is_write_vectored(&self) -> bool {
+        self.inner.is_write_vectored()
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        match this.poll_pending_flush(cx) {
+            Poll::Ready(Ok(())) => {}
+            result => return result,
+        }
+        if this.dirty {
+            if let Err(error) = this.begin_flush() {
+                return Poll::Ready(Err(error));
+            }
+        }
+        this.poll_pending_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.as_mut().poll_flush(cx) {
+            Poll::Ready(Ok(())) => Pin::new(&mut self.get_mut().inner).poll_shutdown(cx),
+            result => result,
+        }
+    }
+}
+
+impl<T: AsHandle> Drop for PipeStream<T> {
+    fn drop(&mut self) {
+        if self.dirty {
+            // A deliberate duplicate covers pending, cancelled, and failed-but-unobserved
+            // flushes. Each job owns an independent safe handle and may run concurrently.
+            let _ = enqueue_linger(&self.inner);
+        }
+    }
+}
+
+struct FlushJob {
+    file: File,
+}
+
+impl FlushJob {
+    fn run(self) {
+        let _ = self.file.sync_all();
+    }
+}
+
+fn enqueue_linger(stream: &impl AsHandle) -> io::Result<()> {
+    let owned_handle = stream.as_handle().try_clone_to_owned()?;
+    let job = FlushJob {
+        file: File::from(owned_handle),
+    };
+
+    match flush_sender().try_send(job) {
+        Ok(()) => {}
+        Err(TrySendError::Full(job) | TrySendError::Disconnected(job)) => spawn_fallback(job),
+    }
+    Ok(())
+}
+
+fn flush_sender() -> &'static SyncSender<FlushJob> {
+    static FLUSH_SENDER: OnceLock<SyncSender<FlushJob>> = OnceLock::new();
+    FLUSH_SENDER.get_or_init(|| {
+        let (sender, receiver) = sync_channel::<FlushJob>(FLUSH_QUEUE_CAPACITY);
+        let _ = thread::Builder::new()
+            .name("kode-bridge-pipe-flush".to_string())
+            .spawn(move || {
+                while let Ok(job) = receiver.recv() {
+                    job.run();
+                }
+            });
+        sender
+    })
+}
+
+fn spawn_fallback(job: FlushJob) {
+    let job = Arc::new(Mutex::new(Some(job)));
+    let worker_job = Arc::clone(&job);
+    if thread::Builder::new()
+        .name("kode-bridge-pipe-flush-fallback".to_string())
+        .spawn(move || run_flush_job(&worker_job))
+        .is_err()
+    {
+        run_flush_job(&job);
+    }
+}
+
+fn run_flush_job(job: &Mutex<Option<FlushJob>>) {
+    let job = {
+        let mut job = job
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let owned_job = job.take();
+        drop(job);
+        owned_job
+    };
+    if let Some(job) = job {
+        job.run();
+    }
+}
+
+pub(super) fn validate_endpoint(path: &Path) -> io::Result<()> {
+    let bytes = path.as_os_str().as_encoded_bytes();
+    let Some(host_end) = bytes
+        .get(2..)
+        .and_then(|rest| rest.iter().position(|byte| *byte == b'\\'))
+    else {
+        return Err(io::Error::new(io::ErrorKind::Unsupported, "not a named pipe path"));
+    };
+    let pipe_prefix = 2 + host_end;
+    if !bytes.starts_with(br"\\")
+        || bytes.get(pipe_prefix..pipe_prefix + 6) != Some(br"\pipe\")
+        || bytes.len() <= pipe_prefix + 6
+        || path.as_os_str().encode_wide().any(|unit| unit == 0)
+    {
+        return Err(io::Error::new(io::ErrorKind::Unsupported, "not a named pipe path"));
+    }
+    Ok(())
+}
+
+pub(super) async fn connect(path: &Path) -> io::Result<ClientStream> {
+    loop {
+        match ClientOptions::new().open(path) {
+            Ok(client) => return Ok(PipeStream::new(client)),
+            Err(error) if error.raw_os_error() == Some(ERROR_PIPE_BUSY as i32) => {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+pub(crate) struct Listener {
+    path: std::path::PathBuf,
+    options: ListenerOptions,
+    pending: Option<NamedPipeServer>,
+}
+
+#[cfg(feature = "server")]
+impl Listener {
+    pub(crate) fn bind(path: &Path, options: &ListenerOptions) -> io::Result<Self> {
+        let pending = create_instance(path, options, true)?;
+        Ok(Self {
+            path: path.to_path_buf(),
+            options: options.clone(),
+            pending: Some(pending),
+        })
+    }
+
+    pub(crate) async fn accept(&mut self) -> io::Result<ServerStream> {
+        let pending = self
+            .pending
+            .as_ref()
+            .ok_or_else(|| io::Error::other("named pipe listener is unavailable"))?;
+        pending.connect().await?;
+
+        let next = create_instance(&self.path, &self.options, false)?;
+        let connected = self
+            .pending
+            .replace(next)
+            .ok_or_else(|| io::Error::other("named pipe listener is unavailable"))?;
+        Ok(PipeStream::new(connected))
+    }
+}
+
+#[cfg(feature = "server")]
+fn create_instance(path: &Path, options: &ListenerOptions, first: bool) -> io::Result<NamedPipeServer> {
+    let mut server_options = ServerOptions::new();
+    server_options
+        .first_pipe_instance(first)
+        .reject_remote_clients(true)
+        .in_buffer_size(512)
+        .out_buffer_size(512);
+
+    match &options.security_descriptor {
+        Some(descriptor) => {
+            let mut attributes = descriptor.security_attributes();
+            // SAFETY: `attributes` is valid for this synchronous call, and its descriptor is
+            // owned by `options`, which outlives every pipe instance created by this listener.
+            unsafe {
+                server_options.create_with_security_attributes_raw(
+                    path,
+                    (&mut attributes as *mut SECURITY_ATTRIBUTES).cast::<c_void>(),
+                )
+            }
+        }
+        None => server_options.create(path),
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct SecurityDescriptor {
+    pointer: NonNull<c_void>,
+}
+
+impl SecurityDescriptor {
+    pub(super) fn from_sddl(sddl: &str) -> io::Result<Self> {
+        let mut encoded = OsStr::new(sddl).encode_wide().collect::<Vec<_>>();
+        if encoded.contains(&0) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "SDDL cannot contain interior nuls",
+            ));
+        }
+        encoded.extend(iter::once(0));
+        let mut pointer = std::ptr::null_mut();
+        // SAFETY: `encoded` is nul-terminated and remains alive for the call. Windows initializes
+        // `pointer` with LocalAlloc memory on success; `Drop` releases it with `LocalFree`.
+        let converted = unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                encoded.as_ptr(),
+                SDDL_REVISION_1,
+                &mut pointer,
+                std::ptr::null_mut(),
+            )
+        };
+        if converted == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let pointer = NonNull::new(pointer)
+            .ok_or_else(|| io::Error::other("SDDL conversion returned a null security descriptor"))?;
+        Ok(Self { pointer })
+    }
+
+    #[cfg(feature = "server")]
+    const fn security_attributes(&self) -> SECURITY_ATTRIBUTES {
+        SECURITY_ATTRIBUTES {
+            nLength: size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: self.pointer.as_ptr(),
+            bInheritHandle: 0,
+        }
+    }
+}
+
+// SAFETY: the descriptor allocation is immutable after construction and remains valid until Drop.
+unsafe impl Send for SecurityDescriptor {}
+// SAFETY: shared access only reads the immutable descriptor pointer for CreateNamedPipeW.
+unsafe impl Sync for SecurityDescriptor {}
+
+impl Drop for SecurityDescriptor {
+    fn drop(&mut self) {
+        // SAFETY: the pointer was allocated by the SDDL conversion API and is freed exactly once.
+        let _ = unsafe { LocalFree(self.pointer.as_ptr()) };
+    }
+}
+
+#[cfg(all(test, feature = "server"))]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+    use tokio::sync::oneshot;
+
+    static PIPE_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+    fn pipe_path(label: &str) -> String {
+        let sequence = PIPE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        format!(r"\\.\pipe\kode-bridge-{}-{sequence}-{label}", std::process::id())
+    }
+
+    async fn connected_pair(label: &str) -> io::Result<(ServerStream, ClientStream)> {
+        let path = pipe_path(label);
+        let mut options = ServerOptions::new();
+        options
+            .first_pipe_instance(true)
+            .reject_remote_clients(true)
+            .in_buffer_size(512)
+            .out_buffer_size(512);
+        let raw_server = options.create(&path)?;
+        let server_task = tokio::spawn(async move {
+            raw_server.connect().await?;
+            Ok::<_, io::Error>(PipeStream::new(raw_server))
+        });
+        let client = connect(Path::new(&path)).await?;
+        let server = server_task.await.map_err(io::Error::other)??;
+        Ok((server, client))
+    }
+
+    async fn read_payload(client: &mut ClientStream, payload: &[u8]) -> io::Result<()> {
+        let mut received = vec![0; payload.len()];
+        match tokio::time::timeout(Duration::from_secs(5), client.read_exact(&mut received)).await {
+            Ok(result) => {
+                result?;
+            }
+            Err(_elapsed) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "client did not receive the complete named-pipe payload",
+                ));
+            }
+        }
+        assert_eq!(received, payload);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn flush_waits_for_a_slow_reader() -> io::Result<()> {
+        let (mut server, mut client) = connected_pair("flush").await?;
+        let payload = b"final response";
+        server.write_all(payload).await?;
+
+        let mut flush = Box::pin(server.flush());
+        let premature = tokio::time::timeout(Duration::from_millis(50), &mut flush).await;
+        assert!(
+            premature.is_err(),
+            "pipe flush completed before the client read buffered data"
+        );
+
+        read_payload(&mut client, payload).await?;
+        match tokio::time::timeout(Duration::from_secs(5), &mut flush).await {
+            Ok(result) => result?,
+            Err(_elapsed) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "pipe flush did not complete after the client read the response",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn explicit_flushes_do_not_block_other_connections() -> io::Result<()> {
+        let (mut server_one, mut client_one) = connected_pair("independent-flush-one").await?;
+        let (mut server_two, mut client_two) = connected_pair("independent-flush-two").await?;
+        let payload_one = b"first slow response";
+        let payload_two = b"second independent response";
+        server_one.write_all(payload_one).await?;
+        server_two.write_all(payload_two).await?;
+
+        let mut flush_one = Box::pin(server_one.flush());
+        let flush_one_pending =
+            std::future::poll_fn(|cx| Poll::Ready(std::future::Future::poll(flush_one.as_mut(), cx).is_pending()))
+                .await;
+        assert!(flush_one_pending, "first flush completed before its client read");
+
+        let mut flush_two = Box::pin(server_two.flush());
+        let flush_two_pending =
+            std::future::poll_fn(|cx| Poll::Ready(std::future::Future::poll(flush_two.as_mut(), cx).is_pending()))
+                .await;
+        assert!(flush_two_pending, "second flush completed before its client read");
+
+        read_payload(&mut client_two, payload_two).await?;
+        match tokio::time::timeout(Duration::from_secs(5), &mut flush_two).await {
+            Ok(result) => result?,
+            Err(_elapsed) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "second flush was blocked by the first connection",
+                ));
+            }
+        }
+
+        let first_still_pending = tokio::time::timeout(Duration::from_millis(50), &mut flush_one).await;
+        assert!(
+            first_still_pending.is_err(),
+            "first flush completed before its client read"
+        );
+        read_payload(&mut client_one, payload_one).await?;
+        match tokio::time::timeout(Duration::from_secs(5), &mut flush_one).await {
+            Ok(result) => result?,
+            Err(_elapsed) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "first flush did not complete after its client read",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn dirty_drop_lingers_until_the_client_reads() -> io::Result<()> {
+        let (mut server, mut client) = connected_pair("dirty-drop").await?;
+        let payload = b"complete response after direct drop";
+        server.write_all(payload).await?;
+        drop(server);
+
+        read_payload(&mut client, payload).await
+    }
+
+    #[tokio::test]
+    async fn cancelled_flush_then_drop_still_lingers() -> io::Result<()> {
+        let (mut server, mut client) = connected_pair("cancelled-flush").await?;
+        let payload = b"complete response after cancelled flush";
+        server.write_all(payload).await?;
+
+        let mut flush = Box::pin(server.flush());
+        let pending =
+            std::future::poll_fn(|cx| Poll::Ready(std::future::Future::poll(flush.as_mut(), cx).is_pending())).await;
+        assert!(pending, "pipe flush completed before the client read buffered data");
+        drop(flush);
+        drop(server);
+
+        read_payload(&mut client, payload).await
+    }
+
+    #[tokio::test]
+    async fn flush_error_retains_dirty_state_for_retry() -> io::Result<()> {
+        let (mut server, _client) = connected_pair("flush-error").await?;
+        server.dirty = true;
+        server.flush = Some(tokio::task::spawn_blocking(|| {
+            Err(io::Error::other("injected flush failure"))
+        }));
+
+        let result = std::future::poll_fn(|cx| server.poll_pending_flush(cx)).await;
+        assert!(result.is_err());
+        assert!(server.dirty);
+        assert!(server.flush.is_none());
+        server.dirty = false;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn thirty_two_slow_reader_flushes_complete_without_fallback_pressure() -> io::Result<()> {
+        const CLIENTS: usize = 32;
+        let payload = b"slow reader response";
+        let mut clients = Vec::with_capacity(CLIENTS);
+        let mut started_receivers = Vec::with_capacity(CLIENTS);
+        let mut flush_tasks = Vec::with_capacity(CLIENTS);
+
+        for index in 0..CLIENTS {
+            let (mut server, client) = connected_pair(&format!("stress-{index}")).await?;
+            server.write_all(payload).await?;
+            let (started_tx, started_rx) = oneshot::channel();
+            let flush_task = tokio::spawn(async move {
+                let mut flush = Box::pin(server.flush());
+                let mut started_tx = Some(started_tx);
+                std::future::poll_fn(|cx| {
+                    let result = std::future::Future::poll(flush.as_mut(), cx);
+                    if let Some(started_tx) = started_tx.take() {
+                        let _ = started_tx.send(result.is_pending());
+                    }
+                    result
+                })
+                .await
+            });
+            clients.push(client);
+            started_receivers.push(started_rx);
+            flush_tasks.push(flush_task);
+        }
+
+        for started_rx in started_receivers {
+            match tokio::time::timeout(Duration::from_secs(5), started_rx).await {
+                Ok(Ok(true)) => {}
+                Ok(Ok(false)) => {
+                    return Err(io::Error::other(
+                        "named-pipe flush completed before its slow reader consumed data",
+                    ));
+                }
+                Ok(Err(error)) => return Err(io::Error::other(error)),
+                Err(_elapsed) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "named-pipe flush did not reach its first poll",
+                    ));
+                }
+            }
+        }
+        assert!(flush_tasks.iter().all(|task| !task.is_finished()));
+
+        let reads = clients
+            .into_iter()
+            .map(|mut client| async move { read_payload(&mut client, payload).await });
+        for result in futures::future::join_all(reads).await {
+            result?;
+        }
+
+        for flush_task in flush_tasks {
+            match tokio::time::timeout(Duration::from_secs(10), flush_task).await {
+                Ok(Ok(result)) => result?,
+                Ok(Err(error)) => return Err(io::Error::other(error)),
+                Err(_elapsed) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::TimedOut,
+                        "named-pipe flush did not complete after readers consumed every payload",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/tests/ipc_transport.rs
+++ b/tests/ipc_transport.rs
@@ -540,6 +540,7 @@ impl StreamSource for ReadySource {
 }
 
 struct StreamServerGuard {
+    #[cfg(unix)]
     endpoint: PathBuf,
     task: Option<JoinHandle<Result<()>>>,
 }
@@ -567,6 +568,7 @@ impl StreamServerGuard {
         });
         timeout(STARTUP_TIMEOUT, ready_rx).await??;
         Ok(Self {
+            #[cfg(unix)]
             endpoint,
             task: Some(task),
         })

--- a/tests/ipc_transport.rs
+++ b/tests/ipc_transport.rs
@@ -1,0 +1,760 @@
+#![cfg(all(feature = "client", feature = "server"))]
+
+use bytes::Bytes;
+use futures::future::join_all;
+use http::Method;
+use kode_bridge::ipc_http_client::{ClientConfig, IpcHttpClient};
+use kode_bridge::ipc_http_server::{HttpResponse, IpcHttpServer, Router, ServerConfig};
+use kode_bridge::ipc_stream_client::{IpcStreamClient, StreamClientConfig};
+use kode_bridge::ipc_stream_server::{IpcStreamServer, StreamMessage, StreamServerConfig, StreamSource};
+use kode_bridge::pool::PoolConfig;
+use kode_bridge::Result;
+use serde_json::{json, Value};
+use std::error::Error;
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+use std::time::Duration;
+use tokio::sync::{oneshot, Notify};
+use tokio::task::JoinHandle;
+use tokio::time::{timeout, Instant};
+use tokio_stream::StreamExt as _;
+
+type TestResult<T = ()> = std::result::Result<T, Box<dyn Error + Send + Sync>>;
+
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(3);
+const LARGE_BODY_SIZE: usize = 512 * 1024;
+const CONCURRENT_CLIENTS: usize = 32;
+
+static ENDPOINT_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+fn unique_endpoint(label: &str) -> PathBuf {
+    let sequence = ENDPOINT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+
+    #[cfg(unix)]
+    {
+        PathBuf::from(format!("/tmp/kb-{}-{}-{}.sock", std::process::id(), sequence, label))
+    }
+
+    #[cfg(windows)]
+    {
+        PathBuf::from(format!(r"\\.\pipe\kb-{}-{}-{}", std::process::id(), sequence, label))
+    }
+}
+
+const fn client_config(enable_pooling: bool) -> ClientConfig {
+    ClientConfig {
+        default_timeout: REQUEST_TIMEOUT,
+        pool_config: PoolConfig {
+            max_size: CONCURRENT_CLIENTS + 8,
+            min_idle: 0,
+            max_idle_time_ms: 30_000,
+            connection_timeout_ms: 1_000,
+            retry_delay_ms: 5,
+            max_retries: 3,
+            max_concurrent_requests: CONCURRENT_CLIENTS + 8,
+            max_requests_per_second: None,
+        },
+        enable_pooling,
+        max_retries: 3,
+        retry_delay: Duration::from_millis(5),
+        max_concurrent_requests: CONCURRENT_CLIENTS + 8,
+        max_requests_per_second: None,
+    }
+}
+
+fn direct_client(path: &Path) -> TestResult<IpcHttpClient> {
+    Ok(IpcHttpClient::with_config(path, client_config(false))?)
+}
+
+fn pooled_client(path: &Path) -> TestResult<IpcHttpClient> {
+    Ok(IpcHttpClient::with_config(path, client_config(true))?)
+}
+
+fn test_router() -> Router {
+    Router::new()
+        .get("/ready", |_ctx| async { Ok(HttpResponse::text("ready")) })
+        .get("/method", |ctx| async move {
+            HttpResponse::json(&json!({
+                "method": ctx.method.as_str(),
+                "connection_id": ctx.client_info.connection_id,
+            }))
+        })
+        .post("/method", |ctx| async move {
+            HttpResponse::json(&json!({
+                "method": ctx.method.as_str(),
+                "body": ctx.json::<Value>()?,
+            }))
+        })
+        .put("/method", |ctx| async move {
+            HttpResponse::json(&json!({
+                "method": ctx.method.as_str(),
+                "body": ctx.json::<Value>()?,
+            }))
+        })
+        .delete("/method", |ctx| async move {
+            HttpResponse::json(&json!({"method": ctx.method.as_str()}))
+        })
+        .post("/echo", |ctx| async move {
+            let seen = ctx
+                .headers
+                .get("x-kode-test")
+                .and_then(|value| value.to_str().ok())
+                .unwrap_or("missing")
+                .to_owned();
+            Ok(HttpResponse::builder()
+                .header("content-type", "application/json")
+                .header("x-kode-seen", seen)
+                .body(ctx.body)
+                .build())
+        })
+        .get("/connection", |ctx| async move {
+            HttpResponse::json(&json!({"connection_id": ctx.client_info.connection_id}))
+        })
+        .get("/stream", |_ctx| async {
+            Ok(HttpResponse::builder()
+                .header("content-type", "application/x-ndjson")
+                .body(Bytes::from_static(b"{\"sequence\":1}\n{\"sequence\":2}\n"))
+                .build())
+        })
+}
+
+struct HttpServerGuard {
+    endpoint: PathBuf,
+    task: Option<JoinHandle<Result<()>>>,
+}
+
+impl HttpServerGuard {
+    async fn start(endpoint: PathBuf, config: ServerConfig, router: Router) -> TestResult<Self> {
+        let server = IpcHttpServer::with_config(&endpoint, config)?.router(router);
+        Self::start_server(endpoint, server).await
+    }
+
+    async fn start_server(endpoint: PathBuf, mut server: IpcHttpServer) -> TestResult<Self> {
+        let task = tokio::spawn(async move { server.serve().await });
+        let mut guard = Self {
+            endpoint,
+            task: Some(task),
+        };
+        guard.wait_until_ready().await?;
+        Ok(guard)
+    }
+
+    async fn wait_until_ready(&mut self) -> TestResult {
+        let deadline = Instant::now() + STARTUP_TIMEOUT;
+        loop {
+            if self.task.as_ref().is_some_and(JoinHandle::is_finished) {
+                let task = self.task.take().ok_or("missing HTTP IPC server task")?;
+                return match task.await {
+                    Ok(Ok(())) => Err("HTTP IPC server exited before becoming ready".into()),
+                    Ok(Err(error)) => Err(format!("HTTP IPC server failed before readiness: {error}").into()),
+                    Err(error) => Err(error.into()),
+                };
+            }
+
+            let client = direct_client(&self.endpoint)?;
+            if let Ok(Ok(response)) = timeout(Duration::from_millis(250), client.get("/ready").send()).await {
+                if response.is_success() && response.body()? == "ready" {
+                    return Ok(());
+                }
+            }
+
+            if Instant::now() >= deadline {
+                return Err(format!("HTTP IPC server did not become ready at {:?}", self.endpoint).into());
+            }
+            tokio::task::yield_now().await;
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+    }
+
+    async fn stop(mut self) -> TestResult {
+        if let Some(task) = self.task.take() {
+            task.abort();
+            match task.await {
+                Err(error) if error.is_cancelled() => {}
+                Err(error) => return Err(error.into()),
+                Ok(Err(error)) => return Err(error.into()),
+                Ok(Ok(())) => {}
+            }
+        }
+
+        #[cfg(unix)]
+        wait_until_path_removed(&self.endpoint).await?;
+
+        Ok(())
+    }
+}
+
+impl Drop for HttpServerGuard {
+    fn drop(&mut self) {
+        if let Some(task) = &self.task {
+            task.abort();
+        }
+    }
+}
+
+#[cfg(unix)]
+async fn wait_until_path_removed(path: &Path) -> TestResult {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while path.exists() {
+        if Instant::now() >= deadline {
+            return Err(format!("IPC socket path was not removed after listener drop: {path:?}").into());
+        }
+        tokio::task::yield_now().await;
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    Ok(())
+}
+
+const fn server_config() -> ServerConfig {
+    ServerConfig {
+        max_connections: CONCURRENT_CLIENTS + 8,
+        read_timeout: Duration::from_secs(2),
+        write_timeout: Duration::from_secs(2),
+        max_request_size: 2 * 1024 * 1024,
+        max_header_size: 16 * 1024,
+        enable_logging: false,
+        max_requests_per_connection: 64,
+        shutdown_timeout: Duration::from_secs(1),
+    }
+}
+
+fn response_json(response: kode_bridge::ipc_http_client::HttpResponse) -> TestResult<Value> {
+    Ok(response.json_value()?)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn http_methods_headers_and_payloads_round_trip() -> TestResult {
+    let endpoint = unique_endpoint("http-roundtrip");
+    let server = HttpServerGuard::start(endpoint.clone(), server_config(), test_router()).await?;
+    let client = pooled_client(&endpoint)?;
+
+    let get = response_json(client.get("/method").send().await?)?;
+    assert_eq!(get["method"], "GET");
+
+    let post_body = json!({"kind": "post", "value": 7});
+    let post = response_json(client.post("/method").json_body(&post_body).send().await?)?;
+    assert_eq!(post["method"], "POST");
+    assert_eq!(post["body"], post_body);
+
+    let put_body = json!({"kind": "put", "value": 11});
+    let put = response_json(client.put("/method").json_body(&put_body).send().await?)?;
+    assert_eq!(put["method"], "PUT");
+    assert_eq!(put["body"], put_body);
+
+    let delete = response_json(client.delete("/method").send().await?)?;
+    assert_eq!(delete["method"], "DELETE");
+
+    let small_body = json!({"payload": "small"});
+    let small = client
+        .post("/echo")
+        .header("x-kode-test", "header-roundtrip")
+        .json_body(&small_body)
+        .send()
+        .await?;
+    assert_eq!(small.headers()["x-kode-seen"], "header-roundtrip");
+    assert_eq!(small.json_value()?, small_body);
+
+    let large_body = json!({"payload": "x".repeat(LARGE_BODY_SIZE)});
+    let large = client
+        .post("/echo")
+        .header("x-kode-test", "large")
+        .json_body(&large_body)
+        .timeout(Duration::from_secs(10))
+        .send()
+        .await?;
+    assert_eq!(large.json_value()?, large_body);
+
+    drop(client);
+    server.stop().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pooled_connections_are_preheated_reused_and_closed() -> TestResult {
+    let endpoint = unique_endpoint("pool");
+    let server = HttpServerGuard::start(endpoint.clone(), server_config(), test_router()).await?;
+    let client = pooled_client(&endpoint)?;
+
+    client.preheat_for_puts(4).await;
+    let preheated = client.pool_stats().ok_or("pooling unexpectedly disabled")?;
+    assert_eq!(preheated.total_connections, 4);
+    assert_eq!(preheated.active_connections, 0);
+
+    let mut connection_ids = Vec::new();
+    for _ in 0..5 {
+        let response = response_json(client.get("/connection").send().await?)?;
+        connection_ids.push(response["connection_id"].clone());
+    }
+    assert_eq!(connection_ids[0], connection_ids[4]);
+    assert_ne!(connection_ids[0], connection_ids[1]);
+
+    client.close();
+    let closed = client.pool_stats().ok_or("pooling unexpectedly disabled")?;
+    assert_eq!(closed.total_connections, 0);
+    assert_eq!(closed.active_connections, 0);
+
+    drop(client);
+    server.stop().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pooled_connection_reaches_server_request_limit() -> TestResult {
+    let endpoint = unique_endpoint("request-limit");
+    let mut config = server_config();
+    config.max_requests_per_connection = 2;
+    let server = HttpServerGuard::start(endpoint.clone(), config, test_router()).await?;
+    let client = pooled_client(&endpoint)?;
+
+    let first = response_json(client.get("/connection").send().await?)?;
+    let second = response_json(client.get("/connection").send().await?)?;
+    assert_eq!(first["connection_id"], second["connection_id"]);
+
+    let replacement = response_json(client.get("/connection").send().await?)?;
+    assert_ne!(replacement["connection_id"], first["connection_id"]);
+
+    drop(client);
+    server.stop().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn missing_and_duplicate_listeners_fail_without_hanging() -> TestResult {
+    let missing_endpoint = unique_endpoint("missing");
+    let missing_client = direct_client(&missing_endpoint)?;
+    let missing_result = timeout(REQUEST_TIMEOUT, missing_client.get("/ready").send()).await?;
+    drop(missing_client);
+    assert!(missing_result.is_err());
+
+    let endpoint = unique_endpoint("duplicate");
+    let server = HttpServerGuard::start(endpoint.clone(), server_config(), test_router()).await?;
+    let mut duplicate = IpcHttpServer::with_config(&endpoint, server_config())?.router(test_router());
+    let duplicate_result = timeout(Duration::from_secs(1), duplicate.serve()).await?;
+    assert!(duplicate_result.is_err());
+
+    let client = direct_client(&endpoint)?;
+    assert!(client.get("/ready").send().await?.is_success());
+    server.stop().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn request_timeout_does_not_block_follow_up_request() -> TestResult {
+    let endpoint = unique_endpoint("request-timeout");
+    let router = Router::new()
+        .get("/ready", |_ctx| async { Ok(HttpResponse::text("ready")) })
+        .get("/pending", |_ctx| async {
+            std::future::pending::<Result<HttpResponse>>().await
+        });
+    let server = HttpServerGuard::start(endpoint.clone(), server_config(), router).await?;
+    let client = direct_client(&endpoint)?;
+
+    let result = timeout(
+        Duration::from_secs(2),
+        client
+            .get("/pending")
+            .timeout(Duration::from_millis(25))
+            .send(),
+    )
+    .await?;
+    let error = match result {
+        Ok(_) => return Err("pending request unexpectedly succeeded".into()),
+        Err(error) => error,
+    };
+    let message = error.to_string().to_ascii_lowercase();
+    assert!(message.contains("timeout") || message.contains("timed out"));
+
+    let response = timeout(Duration::from_secs(1), client.get("/ready").send()).await??;
+    assert!(response.is_success());
+    drop(client);
+    server.stop().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn cancelling_waiting_request_does_not_block_new_client() -> TestResult {
+    let endpoint = unique_endpoint("request-cancel");
+    let handler_entered = Arc::new(Notify::new());
+    let pending_entered = Arc::clone(&handler_entered);
+    let router = Router::new()
+        .get("/ready", |_ctx| async { Ok(HttpResponse::text("ready")) })
+        .get("/pending", move |_ctx| {
+            let pending_entered = Arc::clone(&pending_entered);
+            async move {
+                pending_entered.notify_one();
+                std::future::pending::<Result<HttpResponse>>().await
+            }
+        });
+    let server = HttpServerGuard::start(endpoint.clone(), server_config(), router).await?;
+
+    let waiting_endpoint = endpoint.clone();
+    let waiting_request = tokio::spawn(async move {
+        let client = direct_client(&waiting_endpoint)?;
+        let result = client.get("/pending").send().await;
+        drop(client);
+        match result {
+            Ok(response) => TestResult::Ok(response),
+            Err(error) => Err(error.into()),
+        }
+    });
+    timeout(Duration::from_secs(1), handler_entered.notified()).await?;
+
+    waiting_request.abort();
+    let cancelled = timeout(Duration::from_secs(1), waiting_request).await?;
+    assert!(cancelled.is_err_and(|error| error.is_cancelled()));
+
+    let client = direct_client(&endpoint)?;
+    let response = timeout(Duration::from_secs(1), client.get("/ready").send()).await??;
+    assert!(response.is_success());
+    drop(client);
+    server.stop().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn thirty_two_clients_connect_concurrently() -> TestResult {
+    let endpoint = unique_endpoint("concurrent");
+    let server = HttpServerGuard::start(endpoint.clone(), server_config(), test_router()).await?;
+
+    let requests = (0..CONCURRENT_CLIENTS).map(|_| {
+        let endpoint = endpoint.clone();
+        tokio::spawn(async move {
+            let client = direct_client(&endpoint)?;
+            let response = client.get("/method").send().await?;
+            drop(client);
+            if response.status() != 200 || response.json_value()?["method"] != "GET" {
+                return Err("unexpected concurrent response".into());
+            }
+            TestResult::Ok(())
+        })
+    });
+
+    for result in join_all(requests).await {
+        result??;
+    }
+
+    server.stop().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn streaming_client_reads_lines_disconnects_and_reconnects() -> TestResult {
+    let endpoint = unique_endpoint("stream-client");
+    let server = HttpServerGuard::start(endpoint.clone(), server_config(), test_router()).await?;
+    let config = StreamClientConfig {
+        default_timeout: REQUEST_TIMEOUT,
+        max_retries: 3,
+        retry_delay: Duration::from_millis(5),
+        buffer_size: 8192,
+    };
+
+    let client = IpcStreamClient::with_config(&endpoint, config.clone())?;
+    let mut response = client.get("/stream").send().await?.into_inner();
+    assert_eq!(response.status_code(), 200);
+    assert_eq!(
+        response.next().await.ok_or("missing first stream line")??,
+        r#"{"sequence":1}"#
+    );
+    drop(response);
+
+    let reconnected = IpcStreamClient::with_config(&endpoint, config)?;
+    let mut response = reconnected.get("/stream").send().await?.into_inner();
+    assert_eq!(
+        response
+            .next()
+            .await
+            .ok_or("missing reconnected stream line")??,
+        r#"{"sequence":1}"#
+    );
+    assert_eq!(
+        response
+            .next()
+            .await
+            .ok_or("missing second stream line")??,
+        r#"{"sequence":2}"#
+    );
+    drop(response);
+
+    server.stop().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn streaming_clients_connect_concurrently() -> TestResult {
+    let endpoint = unique_endpoint("stream-concurrent");
+    let server = HttpServerGuard::start(endpoint.clone(), server_config(), test_router()).await?;
+
+    let requests = (0..8).map(|_| {
+        let endpoint = endpoint.clone();
+        tokio::spawn(async move {
+            let client = IpcStreamClient::with_config(
+                &endpoint,
+                StreamClientConfig {
+                    default_timeout: REQUEST_TIMEOUT,
+                    max_retries: 3,
+                    retry_delay: Duration::from_millis(5),
+                    buffer_size: 8192,
+                },
+            )?;
+            let mut response = client.get("/stream").send().await?.into_inner();
+            let line = response
+                .next()
+                .await
+                .ok_or("missing concurrent stream line")??;
+            if line != r#"{"sequence":1}"# {
+                return Err("unexpected concurrent stream response".into());
+            }
+            TestResult::Ok(())
+        })
+    });
+
+    for result in join_all(requests).await {
+        result??;
+    }
+    server.stop().await
+}
+
+struct ReadySource {
+    ready: Option<oneshot::Sender<()>>,
+}
+
+impl StreamSource for ReadySource {
+    fn next_messages(&mut self) -> Pin<Box<dyn Future<Output = Result<Vec<StreamMessage>>> + Send + '_>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn has_more(&self) -> bool {
+        true
+    }
+
+    fn initialize(&mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+        Box::pin(async move {
+            if let Some(ready) = self.ready.take() {
+                let _ = ready.send(());
+            }
+            Ok(())
+        })
+    }
+
+    fn cleanup(&mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+struct StreamServerGuard {
+    endpoint: PathBuf,
+    task: Option<JoinHandle<Result<()>>>,
+}
+
+impl StreamServerGuard {
+    async fn start(endpoint: PathBuf) -> TestResult<Self> {
+        let (ready_tx, ready_rx) = oneshot::channel();
+        let mut server = IpcStreamServer::with_config(
+            &endpoint,
+            StreamServerConfig {
+                max_connections: 8,
+                buffer_size: 8192,
+                write_timeout: Duration::from_secs(1),
+                max_message_size: 64 * 1024,
+                enable_logging: false,
+                shutdown_timeout: Duration::from_millis(250),
+                broadcast_capacity: 16,
+                keepalive_interval: Duration::from_secs(30),
+            },
+        )?;
+        let task = tokio::spawn(async move {
+            server
+                .serve_with_source(ReadySource { ready: Some(ready_tx) })
+                .await
+        });
+        timeout(STARTUP_TIMEOUT, ready_rx).await??;
+        Ok(Self {
+            endpoint,
+            task: Some(task),
+        })
+    }
+
+    async fn stop(mut self) -> TestResult {
+        if let Some(task) = self.task.take() {
+            task.abort();
+            match task.await {
+                Err(error) if error.is_cancelled() => {}
+                Err(error) => return Err(error.into()),
+                Ok(Err(error)) => return Err(error.into()),
+                Ok(Ok(())) => {}
+            }
+        }
+
+        #[cfg(unix)]
+        wait_until_path_removed(&self.endpoint).await?;
+        Ok(())
+    }
+}
+
+impl Drop for StreamServerGuard {
+    fn drop(&mut self) {
+        if let Some(task) = &self.task {
+            task.abort();
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn streaming_server_rejects_duplicate_listener_and_can_restart() -> TestResult {
+    let endpoint = unique_endpoint("stream-server");
+    let server = StreamServerGuard::start(endpoint.clone()).await?;
+
+    let (ready_tx, _ready_rx) = oneshot::channel();
+    let mut duplicate = IpcStreamServer::new(&endpoint)?;
+    let duplicate_result = timeout(
+        Duration::from_secs(1),
+        duplicate.serve_with_source(ReadySource { ready: Some(ready_tx) }),
+    )
+    .await?;
+    assert!(duplicate_result.is_err());
+
+    server.stop().await?;
+    StreamServerGuard::start(endpoint).await?.stop().await
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn unix_stale_socket_and_drop_cleanup_are_preserved() -> TestResult {
+    let stale_endpoint = unique_endpoint("unix-stale");
+    let stale_listener = std::os::unix::net::UnixListener::bind(&stale_endpoint)?;
+    drop(stale_listener);
+    assert!(stale_endpoint.exists());
+
+    let mut stale_server = IpcHttpServer::with_config(&stale_endpoint, server_config())?.router(test_router());
+    let stale_result = timeout(Duration::from_secs(1), stale_server.serve()).await?;
+    assert!(stale_result.is_err());
+    assert!(stale_endpoint.exists());
+    std::fs::remove_file(stale_endpoint)?;
+
+    let cleanup_endpoint = unique_endpoint("unix-cleanup");
+    let server = HttpServerGuard::start(cleanup_endpoint.clone(), server_config(), test_router()).await?;
+    assert!(cleanup_endpoint.exists());
+
+    server.stop().await?;
+    assert!(!cleanup_endpoint.exists());
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn linux_listener_mode_is_applied() -> TestResult {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let endpoint = unique_endpoint("linux-mode");
+    let server = IpcHttpServer::with_config(&endpoint, server_config())?
+        .with_listener_mode(0o640)
+        .router(test_router());
+    let server = HttpServerGuard::start_server(endpoint.clone(), server).await?;
+    let mode = std::fs::metadata(&endpoint)?.permissions().mode() & 0o777;
+    assert_eq!(mode, 0o640);
+    server.stop().await
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn macos_listener_mode_is_currently_unsupported() -> TestResult {
+    let endpoint = unique_endpoint("macos-mode");
+    let mut server = IpcHttpServer::with_config(&endpoint, server_config())?
+        .with_listener_mode(0o640)
+        .router(test_router());
+    let result = timeout(Duration::from_secs(1), server.serve()).await?;
+    let error = match result {
+        Ok(()) => return Err("macOS listener mode unexpectedly succeeded".into()),
+        Err(error) => error,
+    };
+    assert!(error.to_string().contains("unsupported"));
+    assert!(!endpoint.exists());
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn unix_listener_does_not_replace_a_regular_file() -> TestResult {
+    let endpoint = unique_endpoint("regular-file");
+    std::fs::write(&endpoint, b"sentinel")?;
+
+    let mut server = IpcHttpServer::with_config(&endpoint, server_config())?.router(test_router());
+    let serve_result = timeout(Duration::from_secs(1), server.serve()).await?;
+    assert!(serve_result.is_err());
+    assert_eq!(std::fs::read(&endpoint)?, b"sentinel");
+    std::fs::remove_file(endpoint)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn unix_endpoints_with_nul_are_rejected_during_construction() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt as _;
+
+    let endpoint = PathBuf::from(OsString::from_vec(b"/tmp/kb-invalid\0.sock".to_vec()));
+    assert!(IpcHttpClient::new(&endpoint).is_err());
+    assert!(IpcHttpServer::new(endpoint).is_err());
+}
+
+#[cfg(windows)]
+#[test]
+fn windows_non_pipe_endpoints_are_rejected_during_construction() {
+    let endpoint = PathBuf::from(r"C:\temp\kode-bridge-invalid.sock");
+    assert!(IpcHttpClient::new(&endpoint).is_err());
+    assert!(IpcHttpServer::new(endpoint).is_err());
+}
+
+#[cfg(windows)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn windows_sddl_listener_accepts_thirty_two_clients() -> TestResult {
+    let endpoint = unique_endpoint("windows-sddl");
+    let server = IpcHttpServer::with_config(&endpoint, server_config())?
+        .with_listener_security_descriptor("D:(A;;GA;;;WD)")
+        .router(test_router());
+    let server = HttpServerGuard::start_server(endpoint.clone(), server).await?;
+
+    let requests = (0..CONCURRENT_CLIENTS).map(|_| {
+        let endpoint = endpoint.clone();
+        tokio::spawn(async move {
+            let client = direct_client(&endpoint)?;
+            let response = client.get("/ready").send().await?;
+            drop(client);
+            if !response.is_success() {
+                return Err("unexpected Windows SDDL response".into());
+            }
+            TestResult::Ok(())
+        })
+    });
+    for result in join_all(requests).await {
+        result??;
+    }
+
+    server.stop().await
+}
+
+#[cfg(windows)]
+#[test]
+#[should_panic(expected = "Failed to parse SDDL")]
+#[allow(clippy::panic)]
+fn windows_invalid_sddl_is_rejected() {
+    let endpoint = unique_endpoint("windows-invalid-sddl");
+    let server = match IpcHttpServer::new(endpoint) {
+        Ok(server) => server,
+        Err(error) => panic!("server construction should succeed: {error}"),
+    };
+    let _server = server.with_listener_security_descriptor("not-valid-sddl");
+}
+
+#[test]
+fn unique_endpoints_do_not_collide() {
+    let first = unique_endpoint("identity");
+    let second = unique_endpoint("identity");
+    assert_ne!(first, second);
+}
+
+#[test]
+fn router_accepts_all_core_methods() {
+    let router = test_router();
+    for method in [Method::GET, Method::POST, Method::PUT, Method::DELETE] {
+        assert!(router.find_handler_and_params(&method, "/method").is_some());
+    }
+}

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -1,0 +1,38 @@
+#![cfg(feature = "server")]
+
+use kode_bridge::{
+    pool::{ConnectionPool, PoolConfig, PooledConnection},
+    Endpoint, IpcHttpServer, IpcStream, IpcStreamServer, ListenerOptions,
+};
+use tokio::io::{AsyncRead, AsyncWrite};
+
+const fn assert_async_io<T: AsyncRead + AsyncWrite + Unpin + Send>() {}
+
+fn pooled_stream_signatures(mut connection: PooledConnection) {
+    let _borrowed: Option<&mut IpcStream> = connection.stream();
+    let _owned: Option<IpcStream> = connection.into_stream();
+}
+
+#[test]
+fn migration_api_contract_compiles() -> kode_bridge::Result<()> {
+    #[cfg(unix)]
+    let path = "/tmp/kode-bridge-public-api.sock";
+    #[cfg(windows)]
+    let path = r"\\.\pipe\kode-bridge-public-api";
+
+    let endpoint = Endpoint::new(path)?;
+    assert_eq!(endpoint.as_path(), std::path::Path::new(path));
+
+    let listener_options = ListenerOptions::new()
+        .reclaim_name(true)
+        .try_overwrite(false)
+        .max_spin_time(std::time::Duration::from_millis(100));
+    let _server = IpcHttpServer::new(endpoint.as_path())?.with_listener_options(listener_options.clone());
+    let _stream_server = IpcStreamServer::new(endpoint.as_path())?.with_listener_options(listener_options);
+
+    let _pool = ConnectionPool::new(endpoint.clone(), PoolConfig::default());
+    let _default_pool = ConnectionPool::with_default_config(endpoint);
+    let _pooled_api: fn(PooledConnection) = pooled_stream_signatures;
+    assert_async_io::<IpcStream>();
+    Ok(())
+}

--- a/tests/timing_behavior.rs
+++ b/tests/timing_behavior.rs
@@ -81,7 +81,7 @@ impl HttpServerGuard {
     async fn start(endpoint: PathBuf, config: ServerConfig, router: Router) -> TestResult<Self> {
         let mut server = IpcHttpServer::with_config(&endpoint, config)?.router(router);
         let task = tokio::spawn(async move { server.serve().await });
-        let mut guard = Self {
+        let guard = Self {
             endpoint,
             task: Some(task),
         };
@@ -89,7 +89,7 @@ impl HttpServerGuard {
         Ok(guard)
     }
 
-    async fn wait_until_ready(&mut self) -> TestResult {
+    async fn wait_until_ready(&self) -> TestResult {
         let deadline = Instant::now() + STARTUP_TIMEOUT;
         loop {
             if self.task.as_ref().is_some_and(JoinHandle::is_finished) {

--- a/tests/timing_behavior.rs
+++ b/tests/timing_behavior.rs
@@ -1,0 +1,303 @@
+#![cfg(all(feature = "client", feature = "server"))]
+
+use bytes::Bytes;
+use kode_bridge::ipc_http_client::{ClientConfig, IpcHttpClient};
+use kode_bridge::ipc_http_server::{HttpResponse, IpcHttpServer, Router, ServerConfig};
+use kode_bridge::pool::PoolConfig;
+use kode_bridge::retry::{JitterStrategy, RetryConfig, RetryExecutor};
+use kode_bridge::{KodeBridgeError, Result};
+use std::error::Error;
+use std::path::{Path, PathBuf};
+use std::sync::{
+    atomic::{AtomicU64, AtomicUsize, Ordering},
+    Arc,
+};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+use tokio::sync::Notify;
+use tokio::task::JoinHandle;
+use tokio::time::{timeout, Instant};
+
+type TestResult<T = ()> = std::result::Result<T, Box<dyn Error + Send + Sync>>;
+
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(2);
+static ENDPOINT_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+fn unique_endpoint(label: &str) -> PathBuf {
+    let sequence = ENDPOINT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+
+    #[cfg(unix)]
+    {
+        PathBuf::from(format!("/tmp/kb-timing-{}-{sequence}-{label}.sock", std::process::id()))
+    }
+
+    #[cfg(windows)]
+    {
+        PathBuf::from(format!(r"\\.\pipe\kb-timing-{}-{sequence}-{label}", std::process::id()))
+    }
+}
+
+const fn client_config() -> ClientConfig {
+    ClientConfig {
+        default_timeout: REQUEST_TIMEOUT,
+        pool_config: PoolConfig {
+            max_size: 8,
+            min_idle: 0,
+            max_idle_time_ms: 30_000,
+            connection_timeout_ms: 1_000,
+            retry_delay_ms: 5,
+            max_retries: 1,
+            max_concurrent_requests: 8,
+            max_requests_per_second: None,
+        },
+        enable_pooling: false,
+        max_retries: 1,
+        retry_delay: Duration::from_millis(5),
+        max_concurrent_requests: 8,
+        max_requests_per_second: None,
+    }
+}
+
+const fn server_config(max_connections: usize) -> ServerConfig {
+    ServerConfig {
+        max_connections,
+        read_timeout: Duration::from_secs(2),
+        write_timeout: Duration::from_secs(2),
+        max_request_size: 2 * 1024 * 1024,
+        max_header_size: 16 * 1024,
+        enable_logging: false,
+        max_requests_per_connection: 1,
+        shutdown_timeout: Duration::from_secs(1),
+    }
+}
+
+struct HttpServerGuard {
+    endpoint: PathBuf,
+    task: Option<JoinHandle<Result<()>>>,
+}
+
+impl HttpServerGuard {
+    async fn start(endpoint: PathBuf, config: ServerConfig, router: Router) -> TestResult<Self> {
+        let mut server = IpcHttpServer::with_config(&endpoint, config)?.router(router);
+        let task = tokio::spawn(async move { server.serve().await });
+        let mut guard = Self {
+            endpoint,
+            task: Some(task),
+        };
+        guard.wait_until_ready().await?;
+        Ok(guard)
+    }
+
+    async fn wait_until_ready(&mut self) -> TestResult {
+        let deadline = Instant::now() + STARTUP_TIMEOUT;
+        loop {
+            if self.task.as_ref().is_some_and(JoinHandle::is_finished) {
+                return Err("HTTP server exited before readiness".into());
+            }
+
+            let client = IpcHttpClient::with_config(&self.endpoint, client_config())?;
+            if let Ok(Ok(response)) = timeout(Duration::from_millis(250), client.get("/ready").send()).await {
+                if response.is_success() {
+                    return Ok(());
+                }
+            }
+
+            if Instant::now() >= deadline {
+                return Err(format!("HTTP server readiness timed out for {:?}", self.endpoint).into());
+            }
+            tokio::task::yield_now().await;
+        }
+    }
+
+    async fn stop(mut self) -> TestResult {
+        if let Some(task) = self.task.take() {
+            task.abort();
+            match task.await {
+                Err(error) if error.is_cancelled() => {}
+                Err(error) => return Err(error.into()),
+                Ok(Err(error)) => return Err(error.into()),
+                Ok(Ok(())) => {}
+            }
+        }
+
+        #[cfg(unix)]
+        wait_until_path_removed(&self.endpoint).await?;
+        Ok(())
+    }
+}
+
+impl Drop for HttpServerGuard {
+    fn drop(&mut self) {
+        if let Some(task) = &self.task {
+            task.abort();
+        }
+    }
+}
+
+#[cfg(unix)]
+async fn wait_until_path_removed(path: &Path) -> TestResult {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while path.exists() {
+        if Instant::now() >= deadline {
+            return Err(format!("IPC socket was not removed after listener drop: {path:?}").into());
+        }
+        tokio::task::yield_now().await;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+type RawStream = tokio::net::UnixStream;
+#[cfg(windows)]
+type RawStream = tokio::net::windows::named_pipe::NamedPipeClient;
+
+#[cfg(unix)]
+async fn raw_connect(path: &Path) -> std::io::Result<RawStream> {
+    RawStream::connect(path).await
+}
+
+#[cfg(windows)]
+async fn raw_connect(path: &Path) -> std::io::Result<RawStream> {
+    tokio::net::windows::named_pipe::ClientOptions::new().open(path)
+}
+
+async fn read_status(stream: &mut RawStream) -> TestResult {
+    let mut response = [0u8; 128];
+    let bytes_read = timeout(REQUEST_TIMEOUT, stream.read(&mut response)).await??;
+    if !response[..bytes_read].starts_with(b"HTTP/1.1 200") {
+        return Err(format!("unexpected raw HTTP response: {:?}", &response[..bytes_read]).into());
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn fragmented_headers_dispatch_only_after_the_terminator() -> TestResult {
+    let endpoint = unique_endpoint("fragmented-header");
+    let dispatched = Arc::new(Notify::new());
+    let handler_dispatched = Arc::clone(&dispatched);
+    let router = Router::new()
+        .get("/ready", |_ctx| async { Ok(HttpResponse::text("ready")) })
+        .get("/fragmented", move |_ctx| {
+            let dispatched = Arc::clone(&handler_dispatched);
+            async move {
+                dispatched.notify_one();
+                Ok(HttpResponse::text("ok"))
+            }
+        });
+    let server = HttpServerGuard::start(endpoint.clone(), server_config(4), router).await?;
+
+    let mut stream = raw_connect(&endpoint).await?;
+    stream
+        .write_all(b"GET /fragmented HTTP/1.1\r\nHost: timing")
+        .await?;
+    stream.flush().await?;
+    assert!(timeout(Duration::from_millis(50), dispatched.notified())
+        .await
+        .is_err());
+
+    stream.write_all(b"\r\n\r\n").await?;
+    stream.flush().await?;
+    timeout(REQUEST_TIMEOUT, dispatched.notified()).await?;
+    read_status(&mut stream).await?;
+
+    drop(stream);
+    server.stop().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn slow_reader_with_a_spare_permit_does_not_block_a_healthy_client() -> TestResult {
+    let endpoint = unique_endpoint("slow-reader");
+    let response_started = Arc::new(Notify::new());
+    let handler_started = Arc::clone(&response_started);
+    let large_response = Bytes::from(vec![b'x'; 2 * 1024 * 1024]);
+    let router = Router::new()
+        .get("/ready", |_ctx| async { Ok(HttpResponse::text("ready")) })
+        .get("/large", move |_ctx| {
+            let response_started = Arc::clone(&handler_started);
+            let large_response = large_response.clone();
+            async move {
+                response_started.notify_one();
+                Ok(HttpResponse::builder().body(large_response).build())
+            }
+        });
+    let server = HttpServerGuard::start(endpoint.clone(), server_config(2), router).await?;
+
+    let mut slow_reader = raw_connect(&endpoint).await?;
+    slow_reader
+        .write_all(b"GET /large HTTP/1.1\r\nHost: timing\r\n\r\n")
+        .await?;
+    slow_reader.flush().await?;
+    timeout(REQUEST_TIMEOUT, response_started.notified()).await?;
+
+    let healthy = IpcHttpClient::with_config(&endpoint, client_config())?;
+    let response = timeout(REQUEST_TIMEOUT, healthy.get("/ready").send()).await??;
+    assert!(response.is_success());
+
+    drop(slow_reader);
+    drop(healthy);
+    server.stop().await
+}
+
+#[ignore = "candidate acceptance: a bounded response write must release the only connection permit"]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn slow_reader_timeout_releases_the_only_connection_permit() -> TestResult {
+    let endpoint = unique_endpoint("slow-reader-capacity");
+    let response_started = Arc::new(Notify::new());
+    let handler_started = Arc::clone(&response_started);
+    let large_response = Bytes::from(vec![b'x'; 2 * 1024 * 1024]);
+    let router = Router::new()
+        .get("/ready", |_ctx| async { Ok(HttpResponse::text("ready")) })
+        .get("/large", move |_ctx| {
+            let response_started = Arc::clone(&handler_started);
+            let large_response = large_response.clone();
+            async move {
+                response_started.notify_one();
+                Ok(HttpResponse::builder().body(large_response).build())
+            }
+        });
+    let mut config = server_config(1);
+    config.write_timeout = Duration::from_millis(50);
+    let server = HttpServerGuard::start(endpoint.clone(), config, router).await?;
+
+    let mut slow_reader = raw_connect(&endpoint).await?;
+    slow_reader
+        .write_all(b"GET /large HTTP/1.1\r\nHost: timing\r\n\r\n")
+        .await?;
+    slow_reader.flush().await?;
+    timeout(REQUEST_TIMEOUT, response_started.notified()).await?;
+
+    let healthy = IpcHttpClient::with_config(&endpoint, client_config())?;
+    let response = timeout(Duration::from_secs(1), healthy.get("/ready").send()).await??;
+    assert!(response.is_success());
+
+    drop(slow_reader);
+    drop(healthy);
+    server.stop().await
+}
+
+#[tokio::test]
+async fn retry_first_success_has_no_backoff_or_extra_attempt() -> TestResult {
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let operation_attempts = Arc::clone(&attempts);
+    let executor = RetryExecutor::new(
+        RetryConfig::new()
+            .max_attempts(3)
+            .base_delay(Duration::from_secs(1))
+            .jitter(JitterStrategy::None),
+    );
+
+    let result = executor
+        .execute(move || {
+            let attempts = Arc::clone(&operation_attempts);
+            async move {
+                attempts.fetch_add(1, Ordering::Relaxed);
+                Ok::<_, KodeBridgeError>("first-success")
+            }
+        })
+        .await?;
+
+    assert_eq!(result, "first-success");
+    assert_eq!(attempts.load(Ordering::Relaxed), 1);
+    Ok(())
+}

--- a/tests/timing_behavior.rs
+++ b/tests/timing_behavior.rs
@@ -3,18 +3,24 @@
 use bytes::Bytes;
 use kode_bridge::ipc_http_client::{ClientConfig, IpcHttpClient};
 use kode_bridge::ipc_http_server::{HttpResponse, IpcHttpServer, Router, ServerConfig};
+use kode_bridge::ipc_stream_server::{
+    IpcStreamServer, JsonDataSource, StreamMessage, StreamServerConfig, StreamSource,
+};
 use kode_bridge::pool::PoolConfig;
 use kode_bridge::retry::{JitterStrategy, RetryConfig, RetryExecutor};
 use kode_bridge::{KodeBridgeError, Result};
+use serde_json::json;
 use std::error::Error;
+use std::future::Future;
 use std::path::{Path, PathBuf};
+use std::pin::Pin;
 use std::sync::{
     atomic::{AtomicU64, AtomicUsize, Ordering},
     Arc,
 };
 use std::time::Duration;
-use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
-use tokio::sync::Notify;
+use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _, BufReader};
+use tokio::sync::{mpsc, oneshot, Mutex, Notify};
 use tokio::task::JoinHandle;
 use tokio::time::{timeout, Instant};
 
@@ -162,6 +168,137 @@ async fn raw_connect(path: &Path) -> std::io::Result<RawStream> {
     tokio::net::windows::named_pipe::ClientOptions::new().open(path)
 }
 
+struct ChannelSource {
+    messages: Mutex<mpsc::Receiver<StreamMessage>>,
+    initialized: std::sync::Mutex<Option<oneshot::Sender<()>>>,
+}
+
+impl StreamSource for ChannelSource {
+    fn next_messages(&mut self) -> Pin<Box<dyn Future<Output = Result<Vec<StreamMessage>>> + Send + '_>> {
+        Box::pin(async move {
+            let mut messages = self.messages.lock().await;
+            Ok(messages.recv().await.into_iter().collect())
+        })
+    }
+
+    fn has_more(&self) -> bool {
+        true
+    }
+
+    fn initialize(&mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+        Box::pin(async move {
+            let ready = match self.initialized.lock() {
+                Ok(mut initialized) => initialized.take(),
+                Err(error) => error.into_inner().take(),
+            };
+            if let Some(ready) = ready {
+                let _ = ready.send(());
+            }
+            Ok(())
+        })
+    }
+
+    fn cleanup(&mut self) -> Pin<Box<dyn Future<Output = Result<()>> + Send + '_>> {
+        Box::pin(async { Ok(()) })
+    }
+}
+
+struct StreamServerGuard {
+    endpoint: PathBuf,
+    task: Option<JoinHandle<Result<()>>>,
+}
+
+impl StreamServerGuard {
+    async fn start(endpoint: PathBuf, config: StreamServerConfig) -> TestResult<(Self, mpsc::Sender<StreamMessage>)> {
+        let (message_tx, message_rx) = mpsc::channel(16);
+        let (ready_tx, ready_rx) = oneshot::channel();
+        let source = ChannelSource {
+            messages: Mutex::new(message_rx),
+            initialized: std::sync::Mutex::new(Some(ready_tx)),
+        };
+        let mut server = IpcStreamServer::with_config(&endpoint, config)?;
+        let task = tokio::spawn(async move { server.serve_with_source(source).await });
+        timeout(STARTUP_TIMEOUT, ready_rx).await??;
+        Ok((
+            Self {
+                endpoint,
+                task: Some(task),
+            },
+            message_tx,
+        ))
+    }
+
+    async fn stop(mut self) -> TestResult {
+        if let Some(task) = self.task.take() {
+            task.abort();
+            let result = task.await;
+            if !result.is_err_and(|error| error.is_cancelled()) {
+                return Err("stream server did not cancel during test cleanup".into());
+            }
+        }
+
+        #[cfg(unix)]
+        wait_until_path_removed(&self.endpoint).await?;
+        Ok(())
+    }
+}
+
+impl Drop for StreamServerGuard {
+    fn drop(&mut self) {
+        if let Some(task) = &self.task {
+            task.abort();
+        }
+    }
+}
+
+const fn stream_server_config(max_connections: usize, write_timeout: Duration) -> StreamServerConfig {
+    StreamServerConfig {
+        max_connections,
+        buffer_size: 8192,
+        write_timeout,
+        max_message_size: 3 * 1024 * 1024,
+        enable_logging: false,
+        shutdown_timeout: Duration::from_secs(1),
+        broadcast_capacity: 16,
+        keepalive_interval: Duration::from_secs(60),
+    }
+}
+
+async fn publish_until_line(
+    sender: &mpsc::Sender<StreamMessage>,
+    reader: &mut BufReader<RawStream>,
+    message: StreamMessage,
+    expected: &[u8],
+    deadline_after: Duration,
+) -> TestResult {
+    let deadline = Instant::now() + deadline_after;
+    loop {
+        sender.send(message.clone()).await?;
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let mut line = Vec::with_capacity(expected.len());
+        match timeout(
+            Duration::from_millis(25).min(remaining),
+            reader.read_until(b'\n', &mut line),
+        )
+        .await
+        {
+            Ok(Ok(_)) if line == expected => return Ok(()),
+            Ok(Ok(0)) => return Err("stream client closed before receiving a message".into()),
+            Ok(Ok(_)) => return Err(format!("unexpected stream message: {line:?}").into()),
+            Ok(Err(error)) => return Err(error.into()),
+            Err(_) if Instant::now() < deadline => {}
+            Err(_) => return Err("stream client did not subscribe before its deadline".into()),
+        }
+    }
+}
+
+async fn read_stream_line(reader: &mut BufReader<RawStream>, expected: &[u8]) -> TestResult {
+    let mut line = Vec::with_capacity(expected.len());
+    timeout(REQUEST_TIMEOUT, reader.read_until(b'\n', &mut line)).await??;
+    assert_eq!(line, expected);
+    Ok(())
+}
+
 async fn read_status(stream: &mut RawStream) -> TestResult {
     let mut response = [0u8; 128];
     let bytes_read = timeout(REQUEST_TIMEOUT, stream.read(&mut response)).await??;
@@ -239,7 +376,6 @@ async fn slow_reader_with_a_spare_permit_does_not_block_a_healthy_client() -> Te
     server.stop().await
 }
 
-#[ignore = "candidate acceptance: a bounded response write must release the only connection permit"]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn slow_reader_timeout_releases_the_only_connection_permit() -> TestResult {
     let endpoint = unique_endpoint("slow-reader-capacity");
@@ -274,6 +410,107 @@ async fn slow_reader_timeout_releases_the_only_connection_permit() -> TestResult
     drop(slow_reader);
     drop(healthy);
     server.stop().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn streaming_broadcast_preserves_message_bytes() -> TestResult {
+    let endpoint = unique_endpoint("stream-bytes");
+    let (server, sender) =
+        StreamServerGuard::start(endpoint.clone(), stream_server_config(2, Duration::from_secs(1))).await?;
+    let mut reader = BufReader::new(raw_connect(&endpoint).await?);
+
+    publish_until_line(
+        &sender,
+        &mut reader,
+        StreamMessage::text("warmup"),
+        b"warmup\n",
+        REQUEST_TIMEOUT,
+    )
+    .await?;
+
+    sender
+        .send(StreamMessage::Json(json!({"kind":"json"})))
+        .await?;
+    read_stream_line(&mut reader, b"{\"kind\":\"json\"}\n").await?;
+
+    sender.send(StreamMessage::text("text")).await?;
+    read_stream_line(&mut reader, b"text\n").await?;
+
+    sender
+        .send(StreamMessage::binary(Bytes::from_static(b"\x01\x02")))
+        .await?;
+    let mut binary = [0u8; 2];
+    timeout(REQUEST_TIMEOUT, reader.read_exact(&mut binary)).await??;
+    assert_eq!(binary, [1, 2]);
+
+    sender.send(StreamMessage::Ping).await?;
+    read_stream_line(&mut reader, b"PING\n").await?;
+
+    sender.send(StreamMessage::Close).await?;
+    let mut after_close = [0u8; 1];
+    assert_eq!(timeout(REQUEST_TIMEOUT, reader.read(&mut after_close)).await??, 0);
+
+    drop(reader);
+    drop(sender);
+    server.stop().await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn streaming_slow_reader_timeout_releases_the_only_connection_permit() -> TestResult {
+    let endpoint = unique_endpoint("stream-slow-reader");
+    let (server, sender) =
+        StreamServerGuard::start(endpoint.clone(), stream_server_config(1, Duration::from_millis(50))).await?;
+    let mut slow_reader = BufReader::new(raw_connect(&endpoint).await?);
+
+    publish_until_line(
+        &sender,
+        &mut slow_reader,
+        StreamMessage::text("warmup"),
+        b"warmup\n",
+        REQUEST_TIMEOUT,
+    )
+    .await?;
+    sender
+        .send(StreamMessage::binary(Bytes::from(vec![b'x'; 2 * 1024 * 1024])))
+        .await?;
+
+    let mut healthy_reader = BufReader::new(raw_connect(&endpoint).await?);
+    publish_until_line(
+        &sender,
+        &mut healthy_reader,
+        StreamMessage::text("healthy"),
+        b"healthy\n",
+        Duration::from_secs(1),
+    )
+    .await?;
+
+    drop(slow_reader);
+    drop(healthy_reader);
+    drop(sender);
+    server.stop().await
+}
+
+#[tokio::test]
+async fn json_source_waits_for_its_next_deadline() -> TestResult {
+    let interval = Duration::from_millis(25);
+    let mut source = JsonDataSource::new(|| Ok(json!({"kind":"periodic"})), interval);
+    let started = Instant::now();
+    let messages = timeout(REQUEST_TIMEOUT, source.next_messages()).await??;
+
+    assert!(started.elapsed() >= interval);
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].to_bytes().as_ref(), b"{\"kind\":\"periodic\"}\n");
+    Ok(())
+}
+
+#[tokio::test]
+async fn zero_interval_json_source_produces_without_waiting() -> TestResult {
+    let mut source = JsonDataSource::new(|| Ok(json!({"kind":"immediate"})), Duration::ZERO);
+    let messages = timeout(Duration::from_millis(25), source.next_messages()).await??;
+
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0].to_bytes().as_ref(), b"{\"kind\":\"immediate\"}\n");
+    Ok(())
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- kode-bridge 0.5.0 replaces interprocess with the internal Tokio Unix-socket / Windows-named-pipe transport.
- Keeps the HTTP-over-IPC wire protocol and the documented public migration boundary: ListenerOptions, Endpoint/path conversion in ConnectionPool constructors, and IpcStream in pooled stream accessors.
- Preserves Unix cleanup/permissions and Windows SDDL, 512-byte pipe buffers, reject_remote_clients, per-stream flush isolation, and drop linger.
- Adds bounded response write+flush handling, slow-reader capacity coverage, single-encoding Streaming broadcasts, source-driven streaming scheduling, and retry hot-path cleanup.

## Performance And Timing Convergence

The frozen comparison surface keeps these existing files unchanged:

- tests/ipc_transport.rs
- benches/ipc_transport.rs
- benches/bench_version.rs

New hot-path and timing harnesses were committed before production changes. Canonical same-host evidence uses macOS, Rust 1.87.0, release Criterion, and baseline `v0_5_0_baseline_frozen`.

| Case | Frozen baseline | Candidate | Result |
| --- | ---: | ---: | --- |
| Streaming broadcast, 1 client | 12.689 ms | 12.881 us | -99.898% CI |
| Streaming broadcast, 32 clients | 40.699 ms | 69.153 us | -99.865% to -99.943% CI |
| Streaming broadcast, 64 clients | 407.888 ms | 152.887 us | about -99.96% raw ratio |
| Retry first success | 18.086 ns | 14.510 ns | -19.463% to -19.845% CI |

The streaming improvement includes removing the former unconditional 10ms source-loop throttle. Router/query/parser-cache/metrics/pool/codec candidates were not changed because no candidate gain was established.

## Behavior Guarantees

- HTTP normal and Bad Request framed responses are bounded by the existing `write_timeout`, including flush. A timeout exits the connection task and releases its semaphore permit.
- Streaming publishes encode each StreamMessage once into shared `Bytes`. JSON, Text, Binary, Ping, Close, max-message-size, lag, and error semantics are covered by behavior tests.
- Streaming write_all and flush share one deadline. Slow readers leave without blocking healthy clients.
- JsonDataSource waits for its own deadline; IteratorSource waits for readiness and ends at EOF; zero-interval sources cooperatively yield and remain cancellable.
- Retry no longer constructs an unused RNG on the first-success path. Retry count, delay category, jitter behavior, and cancellation points are unchanged.

## Validation

Final head: `2a3834664bde896de2b98b5d36c882c78a1df9d2`

- Final CI: https://github.com/KodeBarinn/kode-bridge/actions/runs/32344216820
- Baseline harness CI: https://github.com/KodeBarinn/kode-bridge/actions/runs/32341979590
- Both runs are green for stable, beta, Rust 1.87, docs, and real Ubuntu/macOS/Windows jobs.
- Local checks passed: `cargo +1.87.0 fmt --all -- --check`, `make check`, `make ci`, `cargo test --all-features`, no-default/client/server/full feature checks, docs, publish dry-run, all benchmark compile checks, and `git diff --check`.
- Timing suite has 8 cross-platform cases, including HTTP and Streaming slow-reader capacity at `max_connections = 1`.
- Independent IRS correctness and simplification reviews found no blockers. The only simplification suggestion was applied and re-reviewed.

## Safety And Platform Evidence

Production unsafe remains limited to src/transport/windows.rs: CreateNamedPipe security attributes, SDDL conversion, Send/Sync justification, and exactly-once LocalFree. No unsafe, public API, dependency, or MSRV expansion was added.

Windows CI functionally covers valid/invalid SDDL, concurrent named-pipe instances, flush cancellation/drop linger, and the new timing suite. CI is not a cross-integrity-level ACL acceptance test, and the fixed ERROR_PIPE_BUSY retry interval has not been characterized with dedicated Windows busy-pressure performance data.

## Merge State

This PR remains Draft pending maintainer review. It is technically green and mergeable, but has no recorded human approval. Do not merge, tag, release, or publish until the owner removes Draft status and completes the repository review process.