### PR TITLE
fix: retry pooled connections closed by server limits

### DIFF
--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -228,7 +228,9 @@ where
 
     // 先读取状态行
     let mut status_line = String::new();
-    reader.read_line(&mut status_line).await?;
+    if reader.read_line(&mut status_line).await? == 0 {
+        return Err(KodeBridgeError::StreamClosed);
+    }
     headers_buffer.extend_from_slice(status_line.as_bytes());
 
     // 读取HTTP头部直到遇到空行
@@ -423,4 +425,30 @@ where
     );
 
     Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn closed_response_stream_is_distinct_from_a_malformed_status() {
+        let (reader, writer) = tokio::io::duplex(1);
+        drop(writer);
+        assert!(matches!(
+            parse_response(reader).await,
+            Err(KodeBridgeError::StreamClosed)
+        ));
+
+        let (mut writer, reader) = tokio::io::duplex(64);
+        writer
+            .write_all(b"not an HTTP status\r\n\r\n")
+            .await
+            .unwrap();
+        drop(writer);
+        assert!(matches!(
+            parse_response(reader).await,
+            Err(KodeBridgeError::Protocol { .. })
+        ));
+    }
 }


### PR DESCRIPTION
## Windows pooled-connection EOF handling

Fixes the intermittent Windows CI failure in `pooled_connection_reaches_server_request_limit` observed on dev run [32349618940](https://github.com/KodeBarinn/kode-bridge/actions/runs/32349618940/job/96365706549).

When a server closes a connection after `max_requests_per_connection`, the pool can borrow the pipe before EOF is observed. A zero-byte initial response status line is now classified as the existing retryable `StreamClosed`; a nonempty malformed or truncated status line remains the non-retryable `Protocol` error. The failed pooled connection is already invalidated before the retry obtains a replacement.

Scope: one production module, no public API/dependency/configuration/Windows transport changes, and no edits to frozen IPC integration or benchmark harnesses.

Validation:
- focused EOF/malformed-status unit test
- `cargo +1.87.0 test --all-features`
- no-default/client/server/full feature checks
- strict Clippy, format, and diff check
- independent correctness and simplification reviews with no blockers

Required acceptance: new branch CI, especially Windows IPC integration and complete test suite.