### PR TITLE
release: kode-bridge 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-08-20
+
+### Added
+
+- Restore Unix peer UID/GID in `RequestContext::client_info` through the public `PeerCredentials` type. Credentials are read from the accepted kernel socket before HTTP framing and remain fixed for the lifetime of that connection.
+- Restore `ClientConfig::windows_server_pid_verifier` and `ClientConfig::require_windows_server_system`. Verification runs before a new Windows named-pipe connection can send a request, including pooled and replacement connections.
+
+### Changed
+
+- Complete `ClientConfig` and `ClientInfo` struct literals must include the restored identity fields. Prefer `..Default::default()` for `ClientConfig`; `ClientInfo` literals must provide `PeerCredentials` explicitly.
+
+### Fixed
+
+- Apply configured Unix listener modes on macOS after bind and before listen, with the same socket type and device/inode revalidation used on other Unix platforms.
+
+### Security
+
+- Reject accepted Unix connections when kernel peer credentials cannot be read instead of substituting an identity.
+- Keep caller-defined Windows service policy outside kode-bridge while allowing clients to require LocalSystem or validate the connected server PID against an external service manager.
+
 ## [0.5.0] - 2026-08-15
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "kode-bridge"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kode-bridge"
 authors = ["Tunglies"]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Modern HTTP Over IPC library for Rust with both client and server support (Unix sockets, Windows named pipes)."
 license = "Apache-2.0"
@@ -58,6 +58,8 @@ windows-sys = { version = "0.61.2", features = [
     "Win32_Foundation",
     "Win32_Security",
     "Win32_Security_Authorization",
+    "Win32_System_Pipes",
+    "Win32_System_Threading",
 ] }
 
 [dev-dependencies]

--- a/PLATFORM_GUIDE.md
+++ b/PLATFORM_GUIDE.md
@@ -102,13 +102,14 @@ cannot modify.
 Custom listener mode is applied before listening on supported Unix platforms:
 
 ```rust
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 let server = kode_bridge::IpcHttpServer::new("/run/my-app/service.sock")?
     .with_listener_mode(0o660);
 ```
 
-Custom mode currently returns `Unsupported` on macOS. Directory ownership and
-permissions remain the primary production access boundary.
+The mode is applied after bind and before listen on Linux and macOS, followed
+by a device/inode identity check. Directory ownership and permissions remain
+the primary production access boundary.
 
 ## Windows listener behavior
 

--- a/SERVER_GUIDE.md
+++ b/SERVER_GUIDE.md
@@ -179,14 +179,15 @@ initialized, but `serve(&mut self)` holds the mutable server borrow. Version
 ### Unix
 
 ```rust
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 let server = IpcHttpServer::new("/run/my-app/service.sock")?
     .with_listener_mode(0o660);
 ```
 
 The default listener removes its own socket path when dropped. It does not
 overwrite a stale path unless `ListenerOptions::try_overwrite(true)` is set.
-Use a trusted parent directory. Custom mode is currently unsupported on macOS.
+Use a trusted parent directory. Custom mode is applied after bind and before
+listen on Linux and macOS.
 
 ### Windows
 

--- a/benches/hot_path.rs
+++ b/benches/hot_path.rs
@@ -124,6 +124,9 @@ const fn client_config(enable_pooling: bool) -> ClientConfig {
         retry_delay: Duration::from_millis(5),
         max_concurrent_requests: MAX_POOL_SIZE,
         max_requests_per_second: None,
+        require_windows_server_system: false,
+        #[cfg(windows)]
+        windows_server_pid_verifier: None,
     }
 }
 

--- a/benches/ipc_transport.rs
+++ b/benches/ipc_transport.rs
@@ -130,6 +130,9 @@ const fn client_config(enable_pooling: bool) -> ClientConfig {
         retry_delay: Duration::from_millis(5),
         max_concurrent_requests: BURST_SIZE + 16,
         max_requests_per_second: None,
+        require_windows_server_system: false,
+        #[cfg(windows)]
+        windows_server_pid_verifier: None,
     }
 }
 

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -69,7 +69,7 @@ let endpoint = r"\\.\pipe\service";
 The convenience builders retain their 0.4 call shape:
 
 ```rust
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 let server = IpcHttpServer::new("/tmp/service.sock")?
     .with_listener_mode(0o640);
 
@@ -96,8 +96,10 @@ Important behavior:
 - Overwrite refuses regular files and listeners that still accept connections.
 - Unix compare-and-delete cannot be made atomic with the safe standard-library
   APIs used here. Put production sockets in a trusted parent directory.
-- Custom Unix mode is applied before listening on supported Unix platforms.
-  It currently returns `Unsupported` on macOS.
+- Custom Unix mode is applied after bind and before listen on Linux and macOS.
+- HTTP request handlers receive the accepted connection's kernel-reported Unix
+  UID/GID through `RequestContext::client_info.peer_credentials`. Connections
+  are rejected if those credentials cannot be read.
 - Windows named pipes reject remote clients. A configured SDDL descriptor is
   applied to every pipe instance.
 - Invalid Windows SDDL retains the 0.4 builder behavior and panics during
@@ -111,6 +113,32 @@ Important behavior:
 - Unix listener cleanup and explicit stale-path policy
 - Windows pipe-busy retry, 512-byte pipe buffers, and flush-on-drop delivery
 - HTTP-style streaming client parsing and newline-delimited stream-server frames
+
+## Identity hooks restored in 0.5.1
+
+The `0.5.1` release restores the identity hooks used by privileged services:
+
+```rust
+let config = kode_bridge::ClientConfig {
+    require_windows_server_system: false,
+    #[cfg(windows)]
+    windows_server_pid_verifier: Some(verify_registered_service_pid),
+    ..Default::default()
+};
+```
+
+On Windows the verifier receives the PID reported by the newly opened named
+pipe handle. It runs once for each physical connection before that connection
+is returned to the caller or pool. Pool reuse does not repeat verification;
+discarding and reconnecting does. `require_windows_server_system` applies the
+library's LocalSystem token check and can be used independently of a custom
+verifier.
+
+This restoration changes complete public struct literals. `ClientConfig`
+literals must include `require_windows_server_system` and, on Windows,
+`windows_server_pid_verifier`, or use `..Default::default()`. `ClientInfo`
+literals must include `peer_credentials: PeerCredentials::default()` when no
+kernel identity is available (for example, in unit-test fixtures).
 
 `IpcStreamClient` and `IpcStreamServer` are not a matched pair in 0.5:
 `IpcStreamClient` consumes an HTTP-style streaming response, while

--- a/docs/platform-configuration.md
+++ b/docs/platform-configuration.md
@@ -86,6 +86,9 @@ let config = ClientConfig {
     retry_delay: Duration::from_millis(25),
     max_concurrent_requests: 16,
     max_requests_per_second: Some(50.0),
+    require_windows_server_system: false,
+    #[cfg(windows)]
+    windows_server_pid_verifier: None,
 };
 
 let client = IpcHttpClient::with_config(endpoint, config)?;
@@ -93,6 +96,12 @@ let client = IpcHttpClient::with_config(endpoint, config)?;
 
 Choose pool limits from measured concurrent demand. A larger pool consumes more
 open handles and memory and does not guarantee lower latency.
+
+On Windows, set `require_windows_server_system` when any LocalSystem pipe
+server is acceptable. Set `windows_server_pid_verifier` when the application
+must compare the PID reported by the connected pipe handle with an external
+service policy such as SCM status. Both checks run before request bytes are
+sent, once per physical connection; pooled reuse does not rerun them.
 
 ## Streaming client configuration
 
@@ -146,14 +155,14 @@ let options = kode_bridge::ListenerOptions::new()
     .try_overwrite(true)
     .max_spin_time(std::time::Duration::from_millis(100));
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 let options = options.mode(0o660);
 ```
 
 - `reclaim_name(true)` is the default.
 - `try_overwrite(false)` is the default.
 - Explicit overwrite refuses non-socket paths and live listeners.
-- Custom mode currently returns `Unsupported` on macOS.
+- Custom mode is applied after bind and before listen on Linux and macOS.
 - Use a trusted parent directory because metadata-check then remove is not an
   atomic compare-and-delete operation.
 

--- a/src/ipc_http_client.rs
+++ b/src/ipc_http_client.rs
@@ -9,6 +9,8 @@ use crate::http_client::{send_request, RequestBuilder, Response};
 use crate::metrics::global_metrics;
 use crate::pool::{ConnectionPool, PoolConfig, PooledConnection};
 use crate::retry::{RetryConfig, RetryExecutor};
+#[cfg(windows)]
+use crate::transport::WindowsServerVerification;
 use crate::transport::{Endpoint, IpcStream};
 use bytes::Bytes;
 use http::Method;
@@ -31,6 +33,16 @@ pub struct ClientConfig {
     pub max_concurrent_requests: usize,
     /// Rate limiting: max requests per second
     pub max_requests_per_second: Option<f64>,
+    /// Require the connected Windows named-pipe server to run as LocalSystem.
+    ///
+    /// This option is ignored on non-Windows platforms.
+    pub require_windows_server_system: bool,
+    /// Verify the process ID behind each new physical Windows named-pipe connection.
+    ///
+    /// Pooled connections are verified once when created. A discarded connection is
+    /// verified again after reconnecting.
+    #[cfg(windows)]
+    pub windows_server_pid_verifier: Option<fn(u32) -> std::io::Result<()>>,
 }
 
 impl Default for ClientConfig {
@@ -43,6 +55,9 @@ impl Default for ClientConfig {
             retry_delay: Duration::from_millis(25), // 减少重试延迟
             max_concurrent_requests: 16,            // 增加并发请求数
             max_requests_per_second: Some(50.0),    // 增加请求速率限制
+            require_windows_server_system: false,
+            #[cfg(windows)]
+            windows_server_pid_verifier: None,
         }
     }
 }
@@ -171,11 +186,21 @@ impl IpcHttpClient {
     {
         let endpoint = Endpoint::new(path)?;
 
-        let pool = if config.enable_pooling {
-            Some(ConnectionPool::new(endpoint.clone(), config.pool_config.clone()))
-        } else {
-            None
-        };
+        #[cfg(windows)]
+        let verification =
+            WindowsServerVerification::new(config.require_windows_server_system, config.windows_server_pid_verifier);
+        #[cfg(windows)]
+        let pool = config.enable_pooling.then(|| {
+            ConnectionPool::new_with_windows_server_verification(
+                endpoint.clone(),
+                config.pool_config.clone(),
+                verification,
+            )
+        });
+        #[cfg(not(windows))]
+        let pool = config
+            .enable_pooling
+            .then(|| ConnectionPool::new(endpoint.clone(), config.pool_config.clone()));
 
         // Create retry executor with optimized configuration for different request types
         let retry_config = RetryConfig::for_network_operations()
@@ -197,6 +222,24 @@ impl IpcHttpClient {
         })
     }
 
+    async fn connect_physical(&self) -> std::io::Result<IpcStream> {
+        #[cfg(windows)]
+        {
+            IpcStream::connect_with_windows_server_verification(
+                &self.endpoint,
+                WindowsServerVerification::new(
+                    self.config.require_windows_server_system,
+                    self.config.windows_server_pid_verifier,
+                ),
+            )
+            .await
+        }
+        #[cfg(not(windows))]
+        {
+            IpcStream::connect(&self.endpoint).await
+        }
+    }
+
     /// Create a direct connection (bypassing pool)
     async fn create_direct_connection(&self) -> Result<IpcStream> {
         let mut last_error = None;
@@ -206,7 +249,7 @@ impl IpcHttpClient {
                 tokio::time::sleep(self.config.retry_delay).await;
             }
 
-            match IpcStream::connect(&self.endpoint).await {
+            match self.connect_physical().await {
                 Ok(stream) => {
                     debug!("Created direct connection on attempt {}", attempt + 1);
                     return Ok(stream);
@@ -418,7 +461,7 @@ impl IpcHttpClient {
         }
 
         // 直接创建连接，使用更快的超时设置
-        match tokio::time::timeout(Duration::from_millis(100), IpcStream::connect(&self.endpoint)).await {
+        match tokio::time::timeout(Duration::from_millis(100), self.connect_physical()).await {
             Ok(Ok(stream)) => Ok(Either::Direct(stream)),
             Ok(Err(_)) | Err(_) => {
                 // 如果直接连接失败，回退到普通池化连接

--- a/src/ipc_http_server.rs
+++ b/src/ipc_http_server.rs
@@ -5,6 +5,8 @@
 
 use crate::codec::HttpIpcCodec;
 use crate::errors::{KodeBridgeError, Result};
+#[cfg(unix)]
+use crate::transport;
 use crate::transport::{Endpoint, Listener, ListenerOptions, ServerStream};
 use bytes::Bytes;
 use futures::{SinkExt as _, StreamExt as _};
@@ -120,6 +122,17 @@ pub struct ClientInfo {
     pub connection_id: u64,
     /// Connection establishment time
     pub connected_at: Instant,
+    /// Kernel-reported credentials for the connected peer.
+    pub peer_credentials: PeerCredentials,
+}
+
+/// Stable subset of platform peer credentials exposed to request handlers.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PeerCredentials {
+    /// Effective Unix user ID. Unavailable on Windows.
+    pub uid: Option<u32>,
+    /// Effective Unix group ID. Unavailable on Windows.
+    pub gid: Option<u32>,
 }
 
 /// Response builder for HTTP responses
@@ -524,6 +537,20 @@ impl IpcHttpServer {
                 accept_result = listener.accept() => {
                     match accept_result {
                         Ok(stream) => {
+                            #[cfg(unix)]
+                            let peer_credentials = match transport::peer_credentials(&stream) {
+                                Ok((uid, gid)) => PeerCredentials {
+                                    uid: Some(uid),
+                                    gid: Some(gid),
+                                },
+                                Err(error) => {
+                                    drop(permit);
+                                    warn!("Rejected connection without peer credentials: {}", error);
+                                    continue;
+                                }
+                            };
+                            #[cfg(windows)]
+                            let peer_credentials = PeerCredentials::default();
                             let connection_id = self.stats.total_connections.fetch_add(1, Ordering::Relaxed) + 1;
                             self.stats.active_connections.fetch_add(1, Ordering::Relaxed);
 
@@ -535,6 +562,7 @@ impl IpcHttpServer {
                                 if let Err(e) = Self::handle_connection(
                                     stream,
                                     connection_id,
+                                    peer_credentials,
                                     router,
                                     config,
                                     Arc::clone(&stats),
@@ -585,6 +613,7 @@ impl IpcHttpServer {
     async fn handle_connection(
         stream: ServerStream,
         connection_id: u64,
+        peer_credentials: PeerCredentials,
         router: Arc<Router>,
         config: ServerConfig,
         stats: Arc<SharedStats>,
@@ -594,6 +623,7 @@ impl IpcHttpServer {
         let client_info = ClientInfo {
             connection_id,
             connected_at: Instant::now(),
+            peer_credentials,
         };
 
         let codec = HttpIpcCodec::new(config.max_header_size, config.max_request_size);
@@ -761,6 +791,7 @@ mod tests {
             client_info: ClientInfo {
                 connection_id: 1,
                 connected_at: Instant::now(),
+                peer_credentials: PeerCredentials::default(),
             },
             timestamp: Instant::now(),
             path_params: HashMap::new(),
@@ -870,6 +901,7 @@ mod tests {
             client_info: ClientInfo {
                 connection_id: 1,
                 connected_at: Instant::now(),
+                peer_credentials: PeerCredentials::default(),
             },
             timestamp: Instant::now(),
             path_params: HashMap::new(),
@@ -913,6 +945,7 @@ mod tests {
             client_info: ClientInfo {
                 connection_id: 1,
                 connected_at: Instant::now(),
+                peer_credentials: PeerCredentials::default(),
             },
             timestamp: Instant::now(),
             path_params: HashMap::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub use ipc_stream_client::*;
 pub use stream_client::*;
 
 #[cfg(feature = "server")]
-pub use ipc_http_server::{IpcHttpServer, RequestContext, Router, ServerConfig};
+pub use ipc_http_server::{ClientInfo, IpcHttpServer, PeerCredentials, RequestContext, Router, ServerConfig};
 
 #[cfg(feature = "server")]
 pub use ipc_stream_server::*;

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,4 +1,6 @@
 use crate::errors::{KodeBridgeError, Result};
+#[cfg(windows)]
+use crate::transport::WindowsServerVerification;
 use crate::transport::{Endpoint, IpcStream};
 use parking_lot::Mutex;
 use std::collections::VecDeque;
@@ -146,6 +148,8 @@ struct ConnectionPoolInner {
     semaphore: Arc<Semaphore>,
     /// Number of checked-out connections currently in use.
     active_connections: std::sync::atomic::AtomicUsize,
+    #[cfg(windows)]
+    windows_server_verification: WindowsServerVerification,
 }
 
 impl ConnectionPoolInner {
@@ -155,7 +159,31 @@ impl ConnectionPoolInner {
             semaphore: Arc::new(Semaphore::new(config.max_size)),
             connections: Mutex::new(VecDeque::new()),
             active_connections: std::sync::atomic::AtomicUsize::new(0),
+            #[cfg(windows)]
+            windows_server_verification: WindowsServerVerification::default(),
             config,
+        }
+    }
+
+    #[cfg(windows)]
+    fn new_with_windows_server_verification(
+        endpoint: Endpoint,
+        config: PoolConfig,
+        verification: WindowsServerVerification,
+    ) -> Self {
+        let mut inner = Self::new(endpoint, config);
+        inner.windows_server_verification = verification;
+        inner
+    }
+
+    async fn connect(&self) -> std::io::Result<IpcStream> {
+        #[cfg(windows)]
+        {
+            IpcStream::connect_with_windows_server_verification(&self.endpoint, self.windows_server_verification).await
+        }
+        #[cfg(not(windows))]
+        {
+            IpcStream::connect(&self.endpoint).await
         }
     }
 
@@ -167,7 +195,7 @@ impl ConnectionPoolInner {
                 tokio::time::sleep(Duration::from_millis(10)).await;
             }
 
-            match IpcStream::connect(&self.endpoint).await {
+            match self.connect().await {
                 Ok(stream) => {
                     debug!("Created fresh connection for PUT request");
                     return Ok(stream);
@@ -195,7 +223,7 @@ impl ConnectionPoolInner {
                 break;
             };
 
-            match IpcStream::connect(&self.endpoint).await {
+            match self.connect().await {
                 Ok(stream) => {
                     self.connections.lock().push_back(IdleConnection {
                         stream,
@@ -227,7 +255,7 @@ impl ConnectionPoolInner {
                 delay = std::cmp::min(delay * 2, max_delay);
             }
 
-            match IpcStream::connect(&self.endpoint).await {
+            match self.connect().await {
                 Ok(stream) => {
                     debug!("Created new connection on attempt {}", attempt + 1);
                     return Ok(stream);
@@ -308,6 +336,21 @@ impl ConnectionPool {
     pub fn new(endpoint: Endpoint, config: PoolConfig) -> Self {
         Self {
             inner: Arc::new(ConnectionPoolInner::new(endpoint, config)),
+        }
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn new_with_windows_server_verification(
+        endpoint: Endpoint,
+        config: PoolConfig,
+        verification: WindowsServerVerification,
+    ) -> Self {
+        Self {
+            inner: Arc::new(ConnectionPoolInner::new_with_windows_server_verification(
+                endpoint,
+                config,
+                verification,
+            )),
         }
     }
 

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -16,6 +16,26 @@ use unix as platform;
 #[cfg(windows)]
 use windows as platform;
 
+#[cfg(windows)]
+pub(crate) type WindowsServerPidVerifier = fn(u32) -> std::io::Result<()>;
+
+#[cfg(windows)]
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct WindowsServerVerification {
+    pub(crate) require_system: bool,
+    pub(crate) verifier: Option<WindowsServerPidVerifier>,
+}
+
+#[cfg(windows)]
+impl WindowsServerVerification {
+    pub(crate) const fn new(require_system: bool, verifier: Option<WindowsServerPidVerifier>) -> Self {
+        Self {
+            require_system,
+            verifier,
+        }
+    }
+}
+
 /// A validated cross-platform IPC endpoint.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct Endpoint(PathBuf);
@@ -154,6 +174,16 @@ impl IpcStream {
     pub(crate) async fn connect(endpoint: &Endpoint) -> std::io::Result<Self> {
         platform::connect(endpoint.as_path()).await.map(Self)
     }
+
+    #[cfg(windows)]
+    pub(crate) async fn connect_with_windows_server_verification(
+        endpoint: &Endpoint,
+        verification: WindowsServerVerification,
+    ) -> std::io::Result<Self> {
+        platform::connect_with_server_verification(endpoint.as_path(), verification)
+            .await
+            .map(Self)
+    }
 }
 
 impl AsyncRead for IpcStream {
@@ -203,4 +233,9 @@ impl Listener {
     pub(crate) async fn accept(&mut self) -> std::io::Result<ServerStream> {
         self.0.accept().await
     }
+}
+
+#[cfg(all(feature = "server", unix))]
+pub(crate) fn peer_credentials(stream: &ServerStream) -> std::io::Result<(u32, u32)> {
+    platform::peer_credentials(stream)
 }

--- a/src/transport/unix.rs
+++ b/src/transport/unix.rs
@@ -53,7 +53,10 @@ impl Listener {
             .then(|| SocketPathGuard::new(path.to_path_buf(), &metadata));
 
         if let Some(mode) = options.mode {
-            std::fs::set_permissions(path, std::fs::Permissions::from_mode(u32::from(mode)))?;
+            // mode_t is u16 on Apple targets and u32 on Linux.
+            #[allow(clippy::useless_conversion)]
+            let mode = u32::from(mode);
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))?;
         }
 
         let current = socket_metadata(path)?;

--- a/src/transport/unix.rs
+++ b/src/transport/unix.rs
@@ -4,7 +4,7 @@ use super::ListenerOptions;
 use std::fs::Metadata;
 use std::io;
 use std::os::unix::ffi::OsStrExt as _;
-#[cfg(all(feature = "server", not(target_os = "macos")))]
+#[cfg(feature = "server")]
 use std::os::unix::fs::PermissionsExt as _;
 #[cfg(feature = "server")]
 use std::os::unix::fs::{FileTypeExt as _, MetadataExt as _};
@@ -46,23 +46,14 @@ pub(crate) struct Listener {
 #[cfg(feature = "server")]
 impl Listener {
     pub(crate) fn bind(path: &Path, options: &ListenerOptions) -> io::Result<Self> {
-        #[cfg(target_os = "macos")]
-        if options.mode.is_some() {
-            return Err(io::Error::new(
-                io::ErrorKind::Unsupported,
-                "Unix listener mode is unsupported on macOS",
-            ));
-        }
-
         let socket = bind_socket(path, options)?;
         let metadata = socket_metadata(path)?;
         let path_guard = options
             .reclaim_name
             .then(|| SocketPathGuard::new(path.to_path_buf(), &metadata));
 
-        #[cfg(not(target_os = "macos"))]
         if let Some(mode) = options.mode {
-            std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))?;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(u32::from(mode)))?;
         }
 
         let current = socket_metadata(path)?;
@@ -86,6 +77,12 @@ impl Listener {
     pub(crate) async fn accept(&mut self) -> io::Result<ServerStream> {
         self.inner.accept().await.map(|(stream, _address)| stream)
     }
+}
+
+#[cfg(feature = "server")]
+pub(crate) fn peer_credentials(stream: &ServerStream) -> io::Result<(u32, u32)> {
+    let credentials = stream.peer_cred()?;
+    Ok((credentials.uid(), credentials.gid()))
 }
 
 #[cfg(feature = "server")]

--- a/src/transport/windows.rs
+++ b/src/transport/windows.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "server")]
 use super::ListenerOptions;
+use super::WindowsServerVerification;
 use std::ffi::{c_void, OsStr};
 use std::fmt;
 use std::fs::File;
@@ -8,7 +9,7 @@ use std::iter;
 #[cfg(feature = "server")]
 use std::mem::size_of;
 use std::os::windows::ffi::OsStrExt as _;
-use std::os::windows::io::AsHandle;
+use std::os::windows::io::{AsHandle, AsRawHandle as _, FromRawHandle as _, OwnedHandle};
 use std::path::Path;
 use std::pin::Pin;
 use std::ptr::NonNull;
@@ -29,6 +30,12 @@ use windows_sys::Win32::Security::Authorization::{
 };
 #[cfg(feature = "server")]
 use windows_sys::Win32::Security::SECURITY_ATTRIBUTES;
+use windows_sys::Win32::Security::{
+    CreateWellKnownSid, EqualSid, GetTokenInformation, TokenUser, WinLocalSystemSid, SECURITY_MAX_SID_SIZE,
+    TOKEN_QUERY, TOKEN_USER,
+};
+use windows_sys::Win32::System::Pipes::GetNamedPipeServerProcessId;
+use windows_sys::Win32::System::Threading::{OpenProcess, OpenProcessToken, PROCESS_QUERY_LIMITED_INFORMATION};
 
 pub(super) type ClientStream = PipeStream<NamedPipeClient>;
 #[cfg(feature = "server")]
@@ -269,15 +276,112 @@ pub(super) fn validate_endpoint(path: &Path) -> io::Result<()> {
 }
 
 pub(super) async fn connect(path: &Path) -> io::Result<ClientStream> {
+    connect_with_server_verification(path, WindowsServerVerification::default()).await
+}
+
+pub(super) async fn connect_with_server_verification(
+    path: &Path,
+    verification: WindowsServerVerification,
+) -> io::Result<ClientStream> {
     loop {
         match ClientOptions::new().open(path) {
-            Ok(client) => return Ok(PipeStream::new(client)),
+            Ok(client) => {
+                verify_server(&client, verification)?;
+                return Ok(PipeStream::new(client));
+            }
             Err(error) if error.raw_os_error() == Some(ERROR_PIPE_BUSY as i32) => {
                 tokio::time::sleep(Duration::from_millis(5)).await;
             }
             Err(error) => return Err(error),
         }
     }
+}
+
+fn verify_server(client: &NamedPipeClient, verification: WindowsServerVerification) -> io::Result<()> {
+    if !verification.require_system && verification.verifier.is_none() {
+        return Ok(());
+    }
+
+    let process_id = pipe_server_process_id(client)?;
+    if verification.require_system {
+        verify_process_is_local_system(process_id)?;
+    }
+    if let Some(verifier) = verification.verifier {
+        verifier(process_id)?;
+    }
+    Ok(())
+}
+
+fn pipe_server_process_id(client: &NamedPipeClient) -> io::Result<u32> {
+    let mut process_id = 0_u32;
+    if unsafe { GetNamedPipeServerProcessId(client.as_raw_handle(), &mut process_id) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if process_id == 0 {
+        return Err(io::Error::other(
+            "Windows named-pipe server returned an invalid process ID",
+        ));
+    }
+    Ok(process_id)
+}
+
+fn verify_process_is_local_system(process_id: u32) -> io::Result<()> {
+    let process = unsafe { OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, process_id) };
+    if process.is_null() {
+        return Err(io::Error::last_os_error());
+    }
+    let process = unsafe { OwnedHandle::from_raw_handle(process) };
+
+    let mut token = std::ptr::null_mut();
+    if unsafe { OpenProcessToken(process.as_raw_handle(), TOKEN_QUERY, &mut token) } == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let token = unsafe { OwnedHandle::from_raw_handle(token) };
+
+    let mut required = 0_u32;
+    unsafe {
+        GetTokenInformation(token.as_raw_handle(), TokenUser, std::ptr::null_mut(), 0, &mut required);
+    }
+    if required == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let words = (required as usize).div_ceil(std::mem::size_of::<usize>());
+    let mut user = vec![0_usize; words];
+    if unsafe {
+        GetTokenInformation(
+            token.as_raw_handle(),
+            TokenUser,
+            user.as_mut_ptr().cast(),
+            required,
+            &mut required,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    let user = unsafe { &*user.as_ptr().cast::<TOKEN_USER>() };
+
+    let sid_words = (SECURITY_MAX_SID_SIZE as usize).div_ceil(std::mem::size_of::<usize>());
+    let mut system_sid = vec![0_usize; sid_words];
+    let mut system_sid_size = SECURITY_MAX_SID_SIZE;
+    if unsafe {
+        CreateWellKnownSid(
+            WinLocalSystemSid,
+            std::ptr::null_mut(),
+            system_sid.as_mut_ptr().cast(),
+            &mut system_sid_size,
+        )
+    } == 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    if unsafe { EqualSid(user.User.Sid, system_sid.as_mut_ptr().cast()) } == 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "Windows named-pipe server is not LocalSystem",
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(feature = "server")]

--- a/tests/ipc_transport.rs
+++ b/tests/ipc_transport.rs
@@ -14,6 +14,8 @@ use std::error::Error;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+#[cfg(windows)]
+use std::sync::atomic::AtomicUsize;
 use std::sync::{
     atomic::{AtomicU64, Ordering},
     Arc,
@@ -65,6 +67,9 @@ const fn client_config(enable_pooling: bool) -> ClientConfig {
         retry_delay: Duration::from_millis(5),
         max_concurrent_requests: CONCURRENT_CLIENTS + 8,
         max_requests_per_second: None,
+        require_windows_server_system: false,
+        #[cfg(windows)]
+        windows_server_pid_verifier: None,
     }
 }
 
@@ -115,6 +120,13 @@ fn test_router() -> Router {
         })
         .get("/connection", |ctx| async move {
             HttpResponse::json(&json!({"connection_id": ctx.client_info.connection_id}))
+        })
+        .get("/identity", |ctx| async move {
+            HttpResponse::json(&json!({
+                "connection_id": ctx.client_info.connection_id,
+                "uid": ctx.client_info.peer_credentials.uid,
+                "gid": ctx.client_info.peer_credentials.gid,
+            }))
         })
         .get("/stream", |_ctx| async {
             Ok(HttpResponse::builder()
@@ -316,6 +328,26 @@ async fn pooled_connection_reaches_server_request_limit() -> TestResult {
 
     let replacement = response_json(client.get("/connection").send().await?)?;
     assert_ne!(replacement["connection_id"], first["connection_id"]);
+
+    drop(client);
+    server.stop().await
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn unix_peer_credentials_are_kernel_reported_and_stable_per_connection() -> TestResult {
+    let endpoint = unique_endpoint("peer-credentials");
+    let server = HttpServerGuard::start(endpoint.clone(), server_config(), test_router()).await?;
+    let client = pooled_client(&endpoint)?;
+
+    let first = response_json(client.get("/identity").send().await?)?;
+    let second = response_json(client.get("/identity").send().await?)?;
+
+    assert_eq!(first["uid"], u64::from(unsafe { libc::geteuid() }));
+    assert_eq!(first["gid"], u64::from(unsafe { libc::getegid() }));
+    assert_eq!(second["uid"], first["uid"]);
+    assert_eq!(second["gid"], first["gid"]);
+    assert_eq!(second["connection_id"], first["connection_id"]);
 
     drop(client);
     server.stop().await
@@ -640,12 +672,12 @@ async fn unix_stale_socket_and_drop_cleanup_are_preserved() -> TestResult {
     Ok(())
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(unix)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn linux_listener_mode_is_applied() -> TestResult {
+async fn unix_listener_mode_is_applied() -> TestResult {
     use std::os::unix::fs::PermissionsExt as _;
 
-    let endpoint = unique_endpoint("linux-mode");
+    let endpoint = unique_endpoint("unix-mode");
     let server = IpcHttpServer::with_config(&endpoint, server_config())?
         .with_listener_mode(0o640)
         .router(test_router());
@@ -653,23 +685,6 @@ async fn linux_listener_mode_is_applied() -> TestResult {
     let mode = std::fs::metadata(&endpoint)?.permissions().mode() & 0o777;
     assert_eq!(mode, 0o640);
     server.stop().await
-}
-
-#[cfg(target_os = "macos")]
-#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn macos_listener_mode_is_currently_unsupported() -> TestResult {
-    let endpoint = unique_endpoint("macos-mode");
-    let mut server = IpcHttpServer::with_config(&endpoint, server_config())?
-        .with_listener_mode(0o640)
-        .router(test_router());
-    let result = timeout(Duration::from_secs(1), server.serve()).await?;
-    let error = match result {
-        Ok(()) => return Err("macOS listener mode unexpectedly succeeded".into()),
-        Err(error) => error,
-    };
-    assert!(error.to_string().contains("unsupported"));
-    assert!(!endpoint.exists());
-    Ok(())
 }
 
 #[cfg(unix)]
@@ -730,6 +745,182 @@ async fn windows_sddl_listener_accepts_thirty_two_clients() -> TestResult {
         result??;
     }
 
+    server.stop().await
+}
+
+#[cfg(windows)]
+static WINDOWS_VERIFIER_SUCCESS_CALLS: AtomicUsize = AtomicUsize::new(0);
+#[cfg(windows)]
+static WINDOWS_VERIFIER_FAILURE_CALLS: AtomicUsize = AtomicUsize::new(0);
+#[cfg(windows)]
+static WINDOWS_VERIFIER_REUSE_CALLS: AtomicUsize = AtomicUsize::new(0);
+#[cfg(windows)]
+static WINDOWS_VERIFIER_RECONNECT_CALLS: AtomicUsize = AtomicUsize::new(0);
+#[cfg(windows)]
+static WINDOWS_VERIFIER_PUT_FALLBACK_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(windows)]
+fn verify_current_process(process_id: u32, calls: &AtomicUsize) -> std::io::Result<()> {
+    calls.fetch_add(1, Ordering::SeqCst);
+    if process_id == std::process::id() {
+        Ok(())
+    } else {
+        Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            "named-pipe server PID did not match the test server",
+        ))
+    }
+}
+
+#[cfg(windows)]
+fn accept_windows_server(process_id: u32) -> std::io::Result<()> {
+    verify_current_process(process_id, &WINDOWS_VERIFIER_SUCCESS_CALLS)
+}
+
+#[cfg(windows)]
+fn reject_windows_server(_process_id: u32) -> std::io::Result<()> {
+    WINDOWS_VERIFIER_FAILURE_CALLS.fetch_add(1, Ordering::SeqCst);
+    Err(std::io::Error::new(
+        std::io::ErrorKind::PermissionDenied,
+        "injected server identity rejection",
+    ))
+}
+
+#[cfg(windows)]
+fn accept_windows_server_for_reuse(process_id: u32) -> std::io::Result<()> {
+    verify_current_process(process_id, &WINDOWS_VERIFIER_REUSE_CALLS)
+}
+
+#[cfg(windows)]
+fn accept_windows_server_for_reconnect(process_id: u32) -> std::io::Result<()> {
+    verify_current_process(process_id, &WINDOWS_VERIFIER_RECONNECT_CALLS)
+}
+
+#[cfg(windows)]
+fn accept_windows_server_for_put_fallback(process_id: u32) -> std::io::Result<()> {
+    verify_current_process(process_id, &WINDOWS_VERIFIER_PUT_FALLBACK_CALLS)
+}
+
+#[cfg(windows)]
+fn windows_verified_client_config(enable_pooling: bool, verifier: fn(u32) -> std::io::Result<()>) -> ClientConfig {
+    let mut config = client_config(enable_pooling);
+    config.max_retries = 1;
+    config.pool_config.max_retries = 1;
+    config.windows_server_pid_verifier = Some(verifier);
+    config
+}
+
+#[cfg(windows)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn windows_server_pid_verifier_accepts_before_request() -> TestResult {
+    WINDOWS_VERIFIER_SUCCESS_CALLS.store(0, Ordering::SeqCst);
+    let endpoint = unique_endpoint("windows-verifier-success");
+    let server = HttpServerGuard::start(endpoint.clone(), server_config(), test_router()).await?;
+    let config = windows_verified_client_config(false, accept_windows_server);
+    let client = IpcHttpClient::with_config(&endpoint, config)?;
+
+    assert!(client.get("/ready").send().await?.is_success());
+    assert_eq!(WINDOWS_VERIFIER_SUCCESS_CALLS.load(Ordering::SeqCst), 1);
+
+    drop(client);
+    server.stop().await
+}
+
+#[cfg(windows)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn windows_server_pid_verifier_rejects_before_request() -> TestResult {
+    WINDOWS_VERIFIER_FAILURE_CALLS.store(0, Ordering::SeqCst);
+    let endpoint = unique_endpoint("windows-verifier-failure");
+    let server = HttpServerGuard::start(endpoint.clone(), server_config(), test_router()).await?;
+    let config = windows_verified_client_config(false, reject_windows_server);
+    let client = IpcHttpClient::with_config(&endpoint, config)?;
+
+    assert!(client.get("/ready").send().await.is_err());
+    assert_eq!(WINDOWS_VERIFIER_FAILURE_CALLS.load(Ordering::SeqCst), 1);
+
+    drop(client);
+    server.stop().await
+}
+
+#[cfg(windows)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn windows_server_pid_verifier_runs_once_for_pooled_connection() -> TestResult {
+    WINDOWS_VERIFIER_REUSE_CALLS.store(0, Ordering::SeqCst);
+    let endpoint = unique_endpoint("windows-verifier-reuse");
+    let server = HttpServerGuard::start(endpoint.clone(), server_config(), test_router()).await?;
+    let config = windows_verified_client_config(true, accept_windows_server_for_reuse);
+    let client = IpcHttpClient::with_config(&endpoint, config)?;
+
+    let first = response_json(client.get("/connection").send().await?)?;
+    let second = response_json(client.get("/connection").send().await?)?;
+    assert_eq!(first["connection_id"], second["connection_id"]);
+    assert_eq!(WINDOWS_VERIFIER_REUSE_CALLS.load(Ordering::SeqCst), 1);
+
+    drop(client);
+    server.stop().await
+}
+
+#[cfg(windows)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn windows_server_pid_verifier_runs_again_after_reconnect() -> TestResult {
+    WINDOWS_VERIFIER_RECONNECT_CALLS.store(0, Ordering::SeqCst);
+    let endpoint = unique_endpoint("windows-verifier-reconnect");
+    let mut server_settings = server_config();
+    server_settings.max_requests_per_connection = 1;
+    let server = HttpServerGuard::start(endpoint.clone(), server_settings, test_router()).await?;
+    let mut config = windows_verified_client_config(true, accept_windows_server_for_reconnect);
+    config.max_retries = 3;
+    config.pool_config.max_retries = 3;
+    let client = IpcHttpClient::with_config(&endpoint, config)?;
+
+    let first = response_json(client.get("/connection").send().await?)?;
+    let second = response_json(client.get("/connection").send().await?)?;
+    assert_ne!(first["connection_id"], second["connection_id"]);
+    assert_eq!(WINDOWS_VERIFIER_RECONNECT_CALLS.load(Ordering::SeqCst), 2);
+
+    drop(client);
+    server.stop().await
+}
+
+#[cfg(windows)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn windows_server_pid_verifier_covers_large_put_direct_fallback() -> TestResult {
+    WINDOWS_VERIFIER_PUT_FALLBACK_CALLS.store(0, Ordering::SeqCst);
+    let endpoint = unique_endpoint("windows-verifier-put-fallback");
+    let server = HttpServerGuard::start(endpoint.clone(), server_config(), test_router()).await?;
+    let mut config = windows_verified_client_config(true, accept_windows_server_for_put_fallback);
+    config.pool_config.max_size = 1;
+    let client = IpcHttpClient::with_config(&endpoint, config)?;
+
+    client.preheat_for_puts(1).await;
+    assert_eq!(WINDOWS_VERIFIER_PUT_FALLBACK_CALLS.load(Ordering::SeqCst), 1);
+
+    let body = Bytes::from(json!({"payload": "x".repeat(12_000)}).to_string());
+    assert!(client
+        .put("/method")
+        .json_bytes(body)
+        .send()
+        .await?
+        .is_success());
+    assert_eq!(WINDOWS_VERIFIER_PUT_FALLBACK_CALLS.load(Ordering::SeqCst), 2);
+
+    drop(client);
+    server.stop().await
+}
+
+#[cfg(windows)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn windows_local_system_requirement_rejects_user_server() -> TestResult {
+    let endpoint = unique_endpoint("windows-require-system");
+    let server = HttpServerGuard::start(endpoint.clone(), server_config(), test_router()).await?;
+    let mut config = client_config(false);
+    config.max_retries = 1;
+    config.require_windows_server_system = true;
+    let client = IpcHttpClient::with_config(&endpoint, config)?;
+
+    assert!(client.get("/ready").send().await.is_err());
+
+    drop(client);
     server.stop().await
 }
 

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -2,7 +2,7 @@
 
 use kode_bridge::{
     pool::{ConnectionPool, PoolConfig, PooledConnection},
-    Endpoint, IpcHttpServer, IpcStream, IpcStreamServer, ListenerOptions,
+    ClientInfo, Endpoint, IpcHttpServer, IpcStream, IpcStreamServer, ListenerOptions, PeerCredentials,
 };
 use tokio::io::{AsyncRead, AsyncWrite};
 
@@ -34,5 +34,23 @@ fn migration_api_contract_compiles() -> kode_bridge::Result<()> {
     let _default_pool = ConnectionPool::with_default_config(endpoint);
     let _pooled_api: fn(PooledConnection) = pooled_stream_signatures;
     assert_async_io::<IpcStream>();
+
+    let unavailable = PeerCredentials::default();
+    assert_eq!(unavailable.uid, None);
+    assert_eq!(unavailable.gid, None);
+    let _client_info = ClientInfo {
+        connection_id: 1,
+        connected_at: std::time::Instant::now(),
+        peer_credentials: unavailable,
+    };
+    #[cfg(feature = "client")]
+    {
+        let config = kode_bridge::ClientConfig::default();
+        assert!(!config.require_windows_server_system);
+        #[cfg(windows)]
+        {
+            let _verifier: Option<fn(u32) -> std::io::Result<()>> = config.windows_server_pid_verifier;
+        }
+    }
     Ok(())
 }

--- a/tests/timing_behavior.rs
+++ b/tests/timing_behavior.rs
@@ -62,6 +62,9 @@ const fn client_config() -> ClientConfig {
         retry_delay: Duration::from_millis(5),
         max_concurrent_requests: 8,
         max_requests_per_second: None,
+        require_windows_server_system: false,
+        #[cfg(windows)]
+        windows_server_pid_verifier: None,
     }
 }
 


### PR DESCRIPTION
## Release 0.5.1

Promotes the validated `dev` head to `main` for the 0.5.1 release.

Includes:

- restored Unix peer UID/GID in `RequestContext::client_info`
- restored Windows server PID verification and optional LocalSystem enforcement
- verification on every new physical Windows named-pipe connection, including reconnects, pooled replacements, and large-PUT fallback connections
- configured Unix listener modes on macOS with socket identity revalidation
- restored 0.4.2 identity-facing public API and 0.5.1 migration documentation

Validation:

- source PR #24 completed all candidate checks
- post-merge `dev` CI [run 32374650940](https://github.com/KodeBarinn/kode-bridge/actions/runs/32374650940) passed all 7 jobs on Ubuntu, macOS, and Windows
- native Windows identity and transport coverage passed

Post-merge `main` CI must pass before the annotated `v0.5.1` tag is pushed. That tag triggers the repository Release workflow, which publishes the crate and creates the GitHub Release.

Source PR: #24
