### PR TITLE
fix: prevent reuse of incomplete pooled HTTP responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2026-09-11
+
+### Fixed
+
+- Return a pooled HTTP connection to the pool only after its response has been read to the end. A request cancelled by its timeout, or by dropping its future, used to hand the connection back with the response still in flight, so the next request on that connection read the stale response instead of its own.
+- Reject invalid or overflowing response `Content-Length` values instead of falling back to idle-based body reads, and consume the entire chunked trailer section before allowing connection reuse. Truncated chunked responses now fail instead of being accepted or waiting indefinitely at EOF.
+
+### Changed
+
+- `PooledConnection::stream` now withdraws the connection from reuse; call the new `PooledConnection::mark_reusable` once the exchange is complete to return it to the pool. `PooledConnection::invalidate` keeps its meaning.
+
 ## [0.5.1] - 2026-08-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Return a pooled HTTP connection to the pool only after its response has been read to the end. A request cancelled by its timeout, or by dropping its future, used to hand the connection back with the response still in flight, so the next request on that connection read the stale response instead of its own.
 - Reject invalid or overflowing response `Content-Length` values instead of falling back to idle-based body reads, and consume the entire chunked trailer section before allowing connection reuse. Truncated chunked responses now fail instead of being accepted or waiting indefinitely at EOF.
+- Accept chunk extensions (`size;name=value`) in chunked responses; they were previously rejected as invalid chunk sizes.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "kode-bridge"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kode-bridge"
 authors = ["Tunglies"]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 description = "Modern HTTP Over IPC library for Rust with both client and server support (Unix sockets, Windows named pipes)."
 license = "Apache-2.0"

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -330,13 +330,20 @@ where
         if reader.read_line(&mut size_line).await? == 0 {
             return Err(KodeBridgeError::StreamClosed);
         }
+        // Accept LF-only endings and chunk extensions ("size;name=value"); an empty
+        // size line still fails because it means the framing has desynchronised.
         let size_line = size_line
-            .strip_suffix("\r\n")
+            .strip_suffix('\n')
             .ok_or_else(|| KodeBridgeError::protocol("Incomplete chunk size line"))?;
+        let size_line = size_line.strip_suffix('\r').unwrap_or(size_line);
+        let size_field = size_line
+            .split_once(';')
+            .map_or(size_line, |(size, _)| size)
+            .trim();
 
         // Parse chunk size (hex)
         let chunk_size =
-            usize::from_str_radix(size_line, 16).map_err(|_| KodeBridgeError::protocol("Invalid chunk size"))?;
+            usize::from_str_radix(size_field, 16).map_err(|_| KodeBridgeError::protocol("Invalid chunk size"))?;
 
         if chunk_size == 0 {
             // Consume trailers through the final empty line before reuse.
@@ -346,10 +353,10 @@ where
                 if reader.read_line(&mut trailer_line).await? == 0 {
                     return Err(KodeBridgeError::StreamClosed);
                 }
-                if trailer_line == "\r\n" {
+                if trailer_line == "\r\n" || trailer_line == "\n" {
                     break;
                 }
-                if !trailer_line.ends_with("\r\n") {
+                if !trailer_line.ends_with('\n') {
                     return Err(KodeBridgeError::protocol("Incomplete chunk trailer"));
                 }
             }
@@ -361,10 +368,13 @@ where
         reader.read_exact(&mut chunk).await?;
         body_buffer.extend_from_slice(&chunk);
 
-        // Read trailing CRLF
-        let mut crlf = [0u8; 2];
-        reader.read_exact(&mut crlf).await?;
-        if crlf != *b"\r\n" {
+        // Chunk data ends with CRLF; tolerate a bare LF.
+        let mut terminator = [0u8; 1];
+        reader.read_exact(&mut terminator).await?;
+        if terminator[0] == b'\r' {
+            reader.read_exact(&mut terminator).await?;
+        }
+        if terminator[0] != b'\n' {
             return Err(KodeBridgeError::protocol("Invalid chunk terminator"));
         }
     }

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -273,11 +273,18 @@ where
         header_map.insert(header_name, header_value);
     }
 
-    // Determine body length
+    // Invalid lengths must not fall back to idle-based reads.
     let content_length = header_map
         .get(header::CONTENT_LENGTH)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse::<usize>().ok());
+        .map(|value| {
+            value
+                .to_str()
+                .ok()
+                .filter(|value| value.bytes().all(|byte| byte.is_ascii_digit()))
+                .and_then(|value| value.parse::<usize>().ok())
+                .ok_or_else(|| KodeBridgeError::protocol("Invalid Content-Length in response"))
+        })
+        .transpose()?;
 
     let is_chunked = header_map
         .get(header::TRANSFER_ENCODING)
@@ -320,21 +327,32 @@ where
     loop {
         // Read chunk size line
         let mut size_line = String::new();
-        reader.read_line(&mut size_line).await?;
-
-        let size_line = size_line.trim();
-        if size_line.is_empty() {
-            continue;
+        if reader.read_line(&mut size_line).await? == 0 {
+            return Err(KodeBridgeError::StreamClosed);
         }
+        let size_line = size_line
+            .strip_suffix("\r\n")
+            .ok_or_else(|| KodeBridgeError::protocol("Incomplete chunk size line"))?;
 
         // Parse chunk size (hex)
         let chunk_size =
             usize::from_str_radix(size_line, 16).map_err(|_| KodeBridgeError::protocol("Invalid chunk size"))?;
 
         if chunk_size == 0 {
-            // Last chunk, read final CRLF
-            let mut final_line = String::new();
-            reader.read_line(&mut final_line).await?;
+            // Consume trailers through the final empty line before reuse.
+            let mut trailer_line = String::new();
+            loop {
+                trailer_line.clear();
+                if reader.read_line(&mut trailer_line).await? == 0 {
+                    return Err(KodeBridgeError::StreamClosed);
+                }
+                if trailer_line == "\r\n" {
+                    break;
+                }
+                if !trailer_line.ends_with("\r\n") {
+                    return Err(KodeBridgeError::protocol("Incomplete chunk trailer"));
+                }
+            }
             break;
         }
 
@@ -346,6 +364,9 @@ where
         // Read trailing CRLF
         let mut crlf = [0u8; 2];
         reader.read_exact(&mut crlf).await?;
+        if crlf != *b"\r\n" {
+            return Err(KodeBridgeError::protocol("Invalid chunk terminator"));
+        }
     }
 
     Ok(body_buffer.freeze())

--- a/src/ipc_http_client.rs
+++ b/src/ipc_http_client.rs
@@ -342,18 +342,7 @@ impl IpcHttpClient {
                     let mut connection = self.get_connection().await?;
 
                     match &mut connection {
-                        Either::Pool(conn) => {
-                            if let Some(stream) = conn.stream() {
-                                let result = send_request(stream, request.clone()).await;
-                                if result.is_err() {
-                                    conn.invalidate();
-                                }
-                                result
-                            } else {
-                                conn.invalidate();
-                                Err(KodeBridgeError::connection("Pooled connection is invalid"))
-                            }
-                        }
+                        Either::Pool(conn) => send_pooled_request(conn, request.clone()).await,
                         Either::Direct(stream) => send_request(stream, request.clone()).await,
                     }
                 })
@@ -423,18 +412,7 @@ impl IpcHttpClient {
                     };
 
                     match &mut connection {
-                        Either::Pool(conn) => {
-                            if let Some(stream) = conn.stream() {
-                                let result = send_request(stream, request.clone()).await;
-                                if result.is_err() {
-                                    conn.invalidate();
-                                }
-                                result
-                            } else {
-                                conn.invalidate();
-                                Err(KodeBridgeError::connection("Pooled connection is invalid"))
-                            }
-                        }
+                        Either::Pool(conn) => send_pooled_request(conn, request.clone()).await,
                         Either::Direct(stream) => send_request(stream, request.clone()).await,
                     }
                 })
@@ -685,6 +663,28 @@ impl<'a> HttpRequestBuilder<'a> {
 enum Either<A, B> {
     Pool(A),
     Direct(B),
+}
+
+/// Restore reuse only after a complete framed response.
+async fn send_pooled_request(conn: &mut PooledConnection, request: Bytes) -> Result<Response> {
+    let Some(stream) = conn.stream() else {
+        return Err(KodeBridgeError::connection("Pooled connection is invalid"));
+    };
+    let response = send_request(stream, request).await?;
+    if leaves_stream_clean(&response) {
+        conn.mark_reusable();
+    }
+    Ok(response)
+}
+
+/// Framing is validated by `send_request`; idle-based reads cannot guarantee completion.
+fn leaves_stream_clean(response: &Response) -> bool {
+    let headers = response.headers();
+    headers.contains_key(http::header::CONTENT_LENGTH)
+        || headers
+            .get(http::header::TRANSFER_ENCODING)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value.eq_ignore_ascii_case("chunked"))
 }
 
 impl Drop for IpcHttpClient {

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -62,7 +62,7 @@ impl PoolConfig {
     }
 }
 
-/// A pooled connection wrapper
+/// A pooled connection wrapper.
 pub struct PooledConnection {
     inner: Option<IpcStream>,
     permit: Option<OwnedSemaphorePermit>,
@@ -85,10 +85,16 @@ impl PooledConnection {
         }
     }
 
-    /// Get the underlying stream
+    /// Borrow the stream, disabling reuse until [`Self::mark_reusable`] is called.
     pub fn stream(&mut self) -> Option<&mut IpcStream> {
         self.last_used = Instant::now();
+        self.reusable = false;
         self.inner.as_mut()
+    }
+
+    /// Allow reuse after the response has been fully consumed.
+    pub const fn mark_reusable(&mut self) {
+        self.reusable = true;
     }
 
     /// Take ownership of the underlying stream


### PR DESCRIPTION
**Problem**

`IpcHttpClient` wraps “take a pooled connection, write the request, read the response” in one `tokio::time::timeout`.

When the timeout fires, the future and its `PooledConnection` are dropped. Previously, the connection remained reusable unless `send_request` returned an error. Cancellation never reached that error-handling code, so the connection could return to the pool with an unfinished response.

The next request could then read the previous response, producing the wrong body or `Failed to parse HTTP response: Version`. This was reliably reproduced with a roughly 4 MiB response and a short client timeout.

**Fix**

Require explicit confirmation before reusing a connection:

- `PooledConnection::stream()` sets `reusable = false`.
- The new `PooledConnection::mark_reusable()` restores reuse eligibility. The client calls it only after `send_request` succeeds with a response framed by `Content-Length` or `chunked`.
- Timeouts, cancellation and errors leave the connection non-reusable, so it closes on drop. `invalidate()` remains available but is no longer needed on these client error paths.

Also tighten response parsing so successful framed responses have actually been read to their end:

- Reject invalid or overflowing `Content-Length` values instead of falling back to idle-based reads.
- Consume all chunked trailers and the terminating empty line before allowing reuse.
- Reject truncated or malformed chunks, including premature EOF.

**Verification**

Temporary regression tests reproduced the timeout-related stale-response bug and the framing issues. They verified that invalid lengths cause connections to be discarded, delayed trailers are fully consumed before reuse, and subsequent requests receive their own responses.

The regression tests passed after the fixes and were removed from the final patch. The full test suite and clippy passed before removal; compilation checks passed afterward.

**Compatibility**

Calling `PooledConnection::stream()` now withdraws the connection from reuse. External callers must call `mark_reusable()` after a complete exchange if they want the connection returned to the pool. Otherwise, it is closed.

This behavior change is documented under Changed in CHANGELOG 0.5.2.